### PR TITLE
#350: CI: docker images missing python

### DIFF
--- a/docker_scripts/ubuntu-20.04-gnu_10-eigen_3.3.7-gtest-trilinos_hash-ef73d14babf6e7556b0420add98cce257ccaa56b.dockerfile
+++ b/docker_scripts/ubuntu-20.04-gnu_10-eigen_3.3.7-gtest-trilinos_hash-ef73d14babf6e7556b0420add98cce257ccaa56b.dockerfile
@@ -13,7 +13,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 # System update and packages installation
 RUN apt-get update && apt-get upgrade -y
 # Installing Utilities
-RUN apt-get install -y wget git make
+RUN apt-get install -y wget git make python3
 # Installing OpenMPI
 RUN apt-get install -y openmpi-bin openmpi-doc
 # Installing BLAS, LAPACK


### PR DESCRIPTION
### THIS PR:
- added python3 to installed packages on docker image with trilinos
- build docker image
- pushed docker image to the repository

Closes #350 