### PR TITLE
Fix `NaN` injection bug in `pressio::ops`

### DIFF
--- a/include/pressio/ops/eigen/ops_elementwise_multiply.hpp
+++ b/include/pressio/ops/eigen/ops_elementwise_multiply.hpp
@@ -76,7 +76,11 @@ elementwise_multiply
   auto & y_n = impl::get_native(y);
   const auto & x_n = impl::get_native(x);
   const auto & z_n = impl::get_native(z);
-  y_n = beta * y_n + alpha * x_n.cwiseProduct(z_n);
+  if (beta == static_cast<typename ::pressio::Traits<T>::scalar_type>(0)) {
+    y_n = alpha * x_n.cwiseProduct(z_n);
+  } else {
+    y_n = beta * y_n + alpha * x_n.cwiseProduct(z_n);
+  }
 }
 
 }}//end namespace pressio::ops

--- a/include/pressio/ops/eigen/ops_level2.hpp
+++ b/include/pressio/ops/eigen/ops_level2.hpp
@@ -84,7 +84,10 @@ product(::pressio::nontranspose mode,
   auto & y_n = impl::get_native(y);
   const auto & A_n = impl::get_native(A);
   const auto & x_n = impl::get_native(x);
-  y_n = beta * y_n + alpha * A_n * x_n;
+  if (beta == static_cast<ScalarType>(0))
+    y_n = alpha * A_n * x_n;
+  else
+    y_n = beta * y_n + alpha * A_n * x_n;
 }
 
 //-------------------------------
@@ -116,7 +119,10 @@ product(::pressio::transpose mode,
   auto & y_n = impl::get_native(y);
   const auto & A_n = impl::get_native(A);
   const auto & x_n = impl::get_native(x);
-  y_n = beta * y_n + alpha * A_n.transpose() * x_n;
+  if (beta == static_cast<ScalarType>(0))
+    y_n = alpha * A_n.transpose() * x_n;
+  else
+    y_n = beta * y_n + alpha * A_n.transpose() * x_n;
 }
 
 //-------------------------------

--- a/include/pressio/ops/eigen/ops_level3.hpp
+++ b/include/pressio/ops/eigen/ops_level3.hpp
@@ -79,7 +79,11 @@ product(::pressio::transpose modeA,
   assert( ::pressio::ops::extent(C, 0) == ::pressio::ops::extent(A, 1) );
   assert( ::pressio::ops::extent(C, 1) == ::pressio::ops::extent(B, 1) );
   assert( ::pressio::ops::extent(A, 0) == ::pressio::ops::extent(B, 0) );
-  C = beta * C + alpha * A.transpose() * B;
+  if (beta == pressio::utils::Constants<ScalarType>::zero()) {
+    C = alpha * A.transpose() * B;
+  } else {
+    C = beta * C + alpha * A.transpose() * B;
+  }
 }
 
 //-------------------------------------------
@@ -106,7 +110,11 @@ product(::pressio::nontranspose modeA,
   assert( ::pressio::ops::extent(C, 0) == ::pressio::ops::extent(A, 0) );
   assert( ::pressio::ops::extent(C, 1) == ::pressio::ops::extent(B, 1) );
   assert( ::pressio::ops::extent(A, 1) == ::pressio::ops::extent(B, 0) );
-  C = beta * C + alpha * A * B;
+  if (beta == pressio::utils::Constants<ScalarType>::zero()) {
+    C = alpha * A * B;
+  } else {
+    C = beta * C + alpha * A * B;
+  }
 }
 
 /***********************************
@@ -127,7 +135,11 @@ product(::pressio::transpose modeA,
   static_assert
     (::pressio::are_scalar_compatible<A_type, C_type>::value,
      "Types are not scalar compatible");
-  C = beta * C + alpha * A.transpose() * A;
+  if (beta == pressio::utils::Constants<ScalarType>::zero()) {
+    C = alpha * A.transpose() * A;
+  } else {
+    C = beta * C + alpha * A.transpose() * A;
+  }
 }
 
 template <typename C_type, typename A_type, typename ScalarType>
@@ -158,8 +170,8 @@ product(::pressio::transpose modeA,
 template <typename A_type, typename B_type, typename ScalarType, typename C_type>
 ::pressio::mpl::enable_if_t<
   ::pressio::is_dense_matrix_eigen<B_type>::value and
-  ::pressio::is_dense_matrix_eigen<C_type>::value and 
-  ::pressio::is_expression_asdiagonalmatrix<A_type>::value and 
+  ::pressio::is_dense_matrix_eigen<C_type>::value and
+  ::pressio::is_expression_asdiagonalmatrix<A_type>::value and
   ::pressio::Traits<A_type>::package_identifier == PackageIdentifier::Eigen
   >
 product(::pressio::nontranspose modeA,
@@ -177,7 +189,11 @@ product(::pressio::nontranspose modeA,
   assert( ::pressio::ops::extent(C, 0) == ::pressio::ops::extent(A, 0) );
   assert( ::pressio::ops::extent(C, 1) == ::pressio::ops::extent(B, 1) );
   assert( ::pressio::ops::extent(A, 1) == ::pressio::ops::extent(B, 0) );
-  C = beta*C + alpha * A.native() * B;
+  if (beta == pressio::utils::Constants<ScalarType>::zero()) {
+    C = alpha * A.native() * B;
+  } else {
+    C = beta*C + alpha * A.native() * B;
+  }
 }
 
 }}//end namespace pressio::ops

--- a/include/pressio/ops/epetra/ops_elementwise_multiply.hpp
+++ b/include/pressio/ops/epetra/ops_elementwise_multiply.hpp
@@ -70,8 +70,9 @@ elementwise_multiply
   assert(x.MyLength()==z.MyLength());
   assert(z.MyLength()==y.MyLength());
   using ord_t = typename ::pressio::Traits<T>::local_ordinal_type;
+  const auto has_beta = beta != static_cast<typename ::pressio::Traits<T>::scalar_type>(0);
   for (ord_t i=0; i<x.MyLength(); ++i){
-    y[i] = beta*y[i] + alpha*x[i]*z[i];
+    y[i] = has_beta ? (beta*y[i] + alpha*x[i]*z[i]) : alpha*x[i]*z[i];
   }
 }
 

--- a/include/pressio/ops/epetra/ops_level2.hpp
+++ b/include/pressio/ops/epetra/ops_level2.hpp
@@ -65,12 +65,12 @@ void _product_epetra_mv_sharedmem_vec(const scalar_type alpha,
 				      const scalar_type beta,
 				      Epetra_Vector & y)
 {
-
+  constexpr auto zero = pressio::utils::Constants<scalar_type>::zero();
   const int numVecs = A.NumVectors();
   using lo_t = typename ::pressio::Traits<A_type>::local_ordinal_type;
   for (lo_t i=0; i< A.MyLength(); i++)
   {
-    y[i] = beta*y[i];
+    y[i] = (beta == zero) ? zero : beta * y[i];
     for (int j=0; j< (int)numVecs; j++){
       y[i] += alpha * A[j][i] * x(j);
     }
@@ -132,11 +132,13 @@ product(::pressio::transpose mode,
   const int numVecs = A.NumVectors();
   assert( (std::size_t)y.length() == (std::size_t)numVecs );
 
-  auto tmp = ::pressio::utils::Constants<scalar_type>::zero();
+  const auto zero = ::pressio::utils::Constants<scalar_type>::zero();
+  auto tmp = zero;
   for (int i=0; i<numVecs; i++)
   {
     A(i)->Dot(x, &tmp);
-    y(i) = beta * y(i) + alpha * tmp;
+    y(i) = (beta == zero) ? zero : beta * y(i);
+    y(i) += alpha * tmp;
   }
 }
 
@@ -195,11 +197,13 @@ product(::pressio::transpose mode,
   const int numVecs = A.NumVectors();
   assert( (std::size_t)y.size() == (std::size_t)numVecs );
 
-  auto tmp = ::pressio::utils::Constants<scalar_type>::zero();
+  const auto zero = ::pressio::utils::Constants<scalar_type>::zero();
+  auto tmp = zero;
   for (int i=0; i<numVecs; i++)
   {
     A(i)->Dot(x, &tmp);
-    y(i) = beta * y(i) + alpha * tmp;
+    y(i) = (beta == zero) ? zero : beta * y(i);
+    y(i) += alpha * tmp;
   }
 }
 #endif

--- a/include/pressio/ops/tpetra/ops_level2.hpp
+++ b/include/pressio/ops/tpetra/ops_level2.hpp
@@ -242,12 +242,14 @@ product(::pressio::transpose mode,
 
   assert(size_t(A.getNumVectors()) == size_t(::pressio::ops::extent(y,0)));
 
+  const auto zero = ::pressio::utils::Constants<scalar_type>::zero();
   const auto numVecs = ::pressio::ops::extent(A, 1);
   for (std::size_t i=0; i<(std::size_t)numVecs; i++)
     {
       // colI is a Teuchos::RCP<Vector<...>>
       const auto colI = A.getVector(i);
-      y(i) = beta * y(i) + alpha * colI->dot(x);
+      y(i) = beta == zero ? zero : beta * y(i);
+      y(i) += alpha * colI->dot(x);
     }
 }
 #endif

--- a/include/pressio/ops/tpetra/ops_level3.hpp
+++ b/include/pressio/ops/tpetra/ops_level3.hpp
@@ -93,7 +93,11 @@ product(::pressio::transpose modeA,
     for (std::size_t j=0; j<(std::size_t)numVecsB; j++)
     {
       const auto colJ = B.getVector(j);
-      C(i,j) = beta * C(i,j) + alpha * colI->dot(*colJ);
+      if (beta == pressio::utils::Constants<scalar_type>::zero()) {
+        C(i,j) = alpha * colI->dot(*colJ);
+      } else {
+        C(i,j) = beta * C(i,j) + alpha * colI->dot(*colJ);
+      }
     }
   }
 }
@@ -154,7 +158,9 @@ product(::pressio::transpose modeA,
   const auto numVecsA = A.getNumVectors();
   assert((std::size_t)C.rows() == (std::size_t)numVecsA);
   assert((std::size_t)C.cols() == (std::size_t)numVecsA);
-  scalar_type tmp = ::pressio::utils::Constants<scalar_type>::zero();
+  const auto zero = pressio::utils::Constants<scalar_type>::zero();
+  const auto has_beta = beta != zero;
+  scalar_type tmp = zero;
 
   // A dot A = A^T*A, which yields a symmetric matrix
   // only need to compute half and fill remaining entries accordingly
@@ -166,9 +172,9 @@ product(::pressio::transpose modeA,
     {
       auto colJ = A.getVector(j);
       tmp = alpha*colI->dot(*colJ);
-      C(i,j) = beta*C(i,j) + tmp;
+      C(i,j) = has_beta ? beta*C(i,j) + tmp : tmp;
       if(j!=i){
-        C(j,i) = beta*C(j,i) + tmp;
+        C(j,i) = has_beta ? beta*C(j,i) + tmp : tmp;
       }
     }
   }

--- a/tests/functional_small/ops/ops_eigen_level2.cc
+++ b/tests/functional_small/ops/ops_eigen_level2.cc
@@ -7,12 +7,19 @@
   M_t M(3,3);                  \
   M << 1.,0.,2.,2.,1.,3.,0.,0.,1.;      \
   Eigen::VectorXd myR(3);      \
+  myR(0) = NAN; /* simulate uninitialized Nan */ \
   constexpr auto beta  = ::pressio::utils::Constants<double>::zero(); \
   constexpr auto alpha = ::pressio::utils::Constants<double>::one();  \
   pressio::ops::product(pressio::nontranspose(), alpha, M, VECIN, beta, myR); \
   EXPECT_DOUBLE_EQ( myR(0), 16.0); \
   EXPECT_DOUBLE_EQ( myR(1), 28.0); \
   EXPECT_DOUBLE_EQ( myR(2), 6.0);  \
+  /* also cover non-zero beta */ \
+  constexpr auto beta1 = ::pressio::utils::Constants<double>::one(); \
+  pressio::ops::product(pressio::nontranspose(), alpha, M, VECIN, beta1, myR); \
+  EXPECT_DOUBLE_EQ( myR(0), 32.0); \
+  EXPECT_DOUBLE_EQ( myR(1), 56.0); \
+  EXPECT_DOUBLE_EQ( myR(2), 12.0);  \
 
 #define OPS_EIGEN_DENSEMATRIX_T_VEC_PROD(VECIN) \
   using M_t = Eigen::MatrixXd; \
@@ -20,12 +27,19 @@
   M << 1.,0.,2.,2.,1.,3.,0.,0.,1.,2.,3.,4.; \
                                \
   Eigen::VectorXd myR(3);      \
+  myR(0) = NAN; /* simulate uninitialized Nan */ \
   constexpr auto beta  = ::pressio::utils::Constants<double>::zero(); \
   constexpr auto alpha = ::pressio::utils::Constants<double>::one();  \
   pressio::ops::product(pressio::transpose(), alpha, M, VECIN, beta, myR); \
   EXPECT_DOUBLE_EQ( myR(0), 14.);  \
   EXPECT_DOUBLE_EQ( myR(1), 11.0); \
   EXPECT_DOUBLE_EQ( myR(2), 8.+6.+6.+12.);  \
+  /* also cover non-zero beta */ \
+  constexpr auto beta1 = ::pressio::utils::Constants<double>::one(); \
+  pressio::ops::product(pressio::transpose(), alpha, M, VECIN, beta1, myR); \
+  EXPECT_DOUBLE_EQ( myR(0), 28.0); \
+  EXPECT_DOUBLE_EQ( myR(1), 22.0); \
+  EXPECT_DOUBLE_EQ( myR(2), 64.0);  \
   auto y = pressio::ops::product<Eigen::VectorXd>(pressio::transpose(), alpha, M, VECIN); \
   EXPECT_DOUBLE_EQ( y(0), 14.);  \
   EXPECT_DOUBLE_EQ( y(1), 11.0); \

--- a/tests/functional_small/ops/ops_eigen_level2.cc
+++ b/tests/functional_small/ops/ops_eigen_level2.cc
@@ -7,7 +7,7 @@
   M_t M(3,3);                  \
   M << 1.,0.,2.,2.,1.,3.,0.,0.,1.;      \
   Eigen::VectorXd myR(3);      \
-  myR(0) = NAN; /* simulate uninitialized Nan */ \
+  myR(0) = std::nan("0"); /* simulate uninitialized NaN */ \
   constexpr auto beta  = ::pressio::utils::Constants<double>::zero(); \
   constexpr auto alpha = ::pressio::utils::Constants<double>::one();  \
   pressio::ops::product(pressio::nontranspose(), alpha, M, VECIN, beta, myR); \
@@ -27,7 +27,7 @@
   M << 1.,0.,2.,2.,1.,3.,0.,0.,1.,2.,3.,4.; \
                                \
   Eigen::VectorXd myR(3);      \
-  myR(0) = NAN; /* simulate uninitialized Nan */ \
+  myR(0) = std::nan("0"); /* simulate uninitialized NaN */ \
   constexpr auto beta  = ::pressio::utils::Constants<double>::zero(); \
   constexpr auto alpha = ::pressio::utils::Constants<double>::one();  \
   pressio::ops::product(pressio::transpose(), alpha, M, VECIN, beta, myR); \
@@ -63,7 +63,7 @@ TEST(ops_eigen, dense_matrix_T_vector_prod)
 TEST(ops_eigen, dense_matrix_span_prod)
 {
   using V_t = Eigen::VectorXd;
-  V_t a(7); 
+  V_t a(7);
   a(3)=4.;
   a(4)=2.;
   a(5)=6.;
@@ -89,7 +89,7 @@ TEST(ops_eigen, dense_matrix_T_span_prod)
 TEST(ops_eigen, dense_matrix_diag_prod)
 {
   using T = Eigen::MatrixXd;
-  T M0(3,3); 
+  T M0(3,3);
   M0(0,0)=4.;
   M0(1,1)=2.;
   M0(2,2)=6.;

--- a/tests/functional_small/ops/ops_eigen_level3.cc
+++ b/tests/functional_small/ops/ops_eigen_level3.cc
@@ -8,7 +8,7 @@ using mat_t = Eigen::MatrixXd;
   mat_t M(4,3);                     \
   M << 1,0,2, 2,1,3, 0,0,1, 2,2,2;\
   mat_t myR(4,4);         \
-  myR(0) = NAN; /* simulate uninitialized Nan */ \
+  myR(0) = std::nan("0"); /* simulate uninitialized NaN */ \
   constexpr auto beta  = ::pressio::utils::Constants<double>::zero(); \
   constexpr auto alpha = ::pressio::utils::Constants<double>::one();  \
   pressio::ops::product(pressio::nontranspose(), pressio::nontranspose(), \
@@ -56,7 +56,7 @@ using mat_t = Eigen::MatrixXd;
   M << 1,0,2, 2,1,3, 0,0,1, 2,2,2;\
                                   \
   mat_t myR(3,3);         \
-  myR(0, 0) = NAN; /* simulate uninitialized Nan */ \
+  myR(0, 0) = std::nan("0"); /* simulate uninitialized NaN */ \
   constexpr auto beta  = ::pressio::utils::Constants<double>::zero(); \
   constexpr auto alpha = ::pressio::utils::Constants<double>::one();  \
   pressio::ops::product(pressio::transpose(), pressio::nontranspose(), \
@@ -90,7 +90,7 @@ using mat_t = Eigen::MatrixXd;
   M << 1,0,2, 2,1,3, 0,0,1, 2,2,2;\
                                   \
   mat_t myR(3,3);         \
-  myR(0, 0) = NAN; /* simulate uninitialized Nan */ \
+  myR(0, 0) = std::nan("0"); /* simulate uninitialized NaN */ \
   constexpr auto beta  = ::pressio::utils::Constants<double>::zero(); \
   constexpr auto alpha = ::pressio::utils::Constants<double>::one();  \
   pressio::ops::product(pressio::transpose(), pressio::nontranspose(), alpha, M, beta, myR); \

--- a/tests/functional_small/ops/ops_eigen_level3.cc
+++ b/tests/functional_small/ops/ops_eigen_level3.cc
@@ -8,6 +8,7 @@ using mat_t = Eigen::MatrixXd;
   mat_t M(4,3);                     \
   M << 1,0,2, 2,1,3, 0,0,1, 2,2,2;\
   mat_t myR(4,4);         \
+  myR(0) = NAN; /* simulate uninitialized Nan */ \
   constexpr auto beta  = ::pressio::utils::Constants<double>::zero(); \
   constexpr auto alpha = ::pressio::utils::Constants<double>::one();  \
   pressio::ops::product(pressio::nontranspose(), pressio::nontranspose(), \
@@ -28,6 +29,26 @@ using mat_t = Eigen::MatrixXd;
   EXPECT_DOUBLE_EQ(myR(3,1), 6.0); \
   EXPECT_DOUBLE_EQ(myR(3,2), 12.0); \
   EXPECT_DOUBLE_EQ(myR(3,3), 18.0); \
+  /* also cover non-zero beta */ \
+  constexpr auto beta1 = ::pressio::utils::Constants<double>::one(); \
+  pressio::ops::product(pressio::nontranspose(), pressio::nontranspose(), \
+      alpha, M, OPERAND, beta1, myR);\
+  EXPECT_DOUBLE_EQ(myR(0,0), 0.0); \
+  EXPECT_DOUBLE_EQ(myR(0,1), 6.0); \
+  EXPECT_DOUBLE_EQ(myR(0,2), 12.0); \
+  EXPECT_DOUBLE_EQ(myR(0,3), 18.0); \
+  EXPECT_DOUBLE_EQ(myR(1,0), 0.0); \
+  EXPECT_DOUBLE_EQ(myR(1,1), 12.0); \
+  EXPECT_DOUBLE_EQ(myR(1,2), 24.0); \
+  EXPECT_DOUBLE_EQ(myR(1,3), 36.0); \
+  EXPECT_DOUBLE_EQ(myR(2,0), 0.0); \
+  EXPECT_DOUBLE_EQ(myR(2,1), 2.0); \
+  EXPECT_DOUBLE_EQ(myR(2,2), 4.0); \
+  EXPECT_DOUBLE_EQ(myR(2,3), 6.0); \
+  EXPECT_DOUBLE_EQ(myR(3,0), 0.0); \
+  EXPECT_DOUBLE_EQ(myR(3,1), 12.0); \
+  EXPECT_DOUBLE_EQ(myR(3,2), 24.0); \
+  EXPECT_DOUBLE_EQ(myR(3,3), 36.0); \
 
 
 #define OPS_EIGEN_DENSE_MAT_T_MAT_PROD(OPERAND) \
@@ -35,6 +56,7 @@ using mat_t = Eigen::MatrixXd;
   M << 1,0,2, 2,1,3, 0,0,1, 2,2,2;\
                                   \
   mat_t myR(3,3);         \
+  myR(0, 0) = NAN; /* simulate uninitialized Nan */ \
   constexpr auto beta  = ::pressio::utils::Constants<double>::zero(); \
   constexpr auto alpha = ::pressio::utils::Constants<double>::one();  \
   pressio::ops::product(pressio::transpose(), pressio::nontranspose(), \
@@ -48,6 +70,19 @@ using mat_t = Eigen::MatrixXd;
   EXPECT_DOUBLE_EQ(myR(2,0), 0.0); \
   EXPECT_DOUBLE_EQ(myR(2,1), 8.0); \
   EXPECT_DOUBLE_EQ(myR(2,2), 16.0); \
+  /* also cover non-zero beta */ \
+  constexpr auto beta1 = ::pressio::utils::Constants<double>::one(); \
+  pressio::ops::product(pressio::transpose(), pressio::nontranspose(), \
+      alpha, M, OPERAND, beta1, myR); \
+  EXPECT_DOUBLE_EQ(myR(0,0), 0.0); \
+  EXPECT_DOUBLE_EQ(myR(0,1), 10.0); \
+  EXPECT_DOUBLE_EQ(myR(0,2), 20.0); \
+  EXPECT_DOUBLE_EQ(myR(1,0), 0.0); \
+  EXPECT_DOUBLE_EQ(myR(1,1), 6.0); \
+  EXPECT_DOUBLE_EQ(myR(1,2), 12.0); \
+  EXPECT_DOUBLE_EQ(myR(2,0), 0.0); \
+  EXPECT_DOUBLE_EQ(myR(2,1), 16.0); \
+  EXPECT_DOUBLE_EQ(myR(2,2), 32.0); \
 
 
 #define OPS_EIGEN_DENSE_MAT_T_SELF_PROD \
@@ -55,6 +90,7 @@ using mat_t = Eigen::MatrixXd;
   M << 1,0,2, 2,1,3, 0,0,1, 2,2,2;\
                                   \
   mat_t myR(3,3);         \
+  myR(0, 0) = NAN; /* simulate uninitialized Nan */ \
   constexpr auto beta  = ::pressio::utils::Constants<double>::zero(); \
   constexpr auto alpha = ::pressio::utils::Constants<double>::one();  \
   pressio::ops::product(pressio::transpose(), pressio::nontranspose(), alpha, M, beta, myR); \
@@ -67,6 +103,18 @@ using mat_t = Eigen::MatrixXd;
   EXPECT_DOUBLE_EQ(myR(2,0), 12.0); \
   EXPECT_DOUBLE_EQ(myR(2,1), 7.0); \
   EXPECT_DOUBLE_EQ(myR(2,2), 18.0); \
+  /* also cover non-zero beta */ \
+  constexpr auto beta1 = ::pressio::utils::Constants<double>::one(); \
+  pressio::ops::product(pressio::transpose(), pressio::nontranspose(), alpha, M, beta1, myR); \
+  EXPECT_DOUBLE_EQ(myR(0,0), 18.0); \
+  EXPECT_DOUBLE_EQ(myR(0,1), 12.0); \
+  EXPECT_DOUBLE_EQ(myR(0,2), 24.0); \
+  EXPECT_DOUBLE_EQ(myR(1,0), 12.0); \
+  EXPECT_DOUBLE_EQ(myR(1,1), 10.0); \
+  EXPECT_DOUBLE_EQ(myR(1,2), 14.0); \
+  EXPECT_DOUBLE_EQ(myR(2,0), 24.0); \
+  EXPECT_DOUBLE_EQ(myR(2,1), 14.0); \
+  EXPECT_DOUBLE_EQ(myR(2,2), 36.0); \
 
 
 namespace {

--- a/tests/functional_small/ops/ops_eigen_vector.cc
+++ b/tests/functional_small/ops/ops_eigen_vector.cc
@@ -188,7 +188,7 @@ TEST(ops_eigen, vector_absPowNeg)
   T y(6);
   T x(6);
   for (int i=0; i<6; ++i){
-    x(i) = (double) i; 
+    x(i) = (double) i;
     x(i)*=-1.;
   }
 
@@ -293,4 +293,11 @@ TEST(ops_eigen, vector_elementwiseMultiply)
   EXPECT_DOUBLE_EQ( y(0), 7.0);
   EXPECT_DOUBLE_EQ( y(1), 14.0);
   EXPECT_DOUBLE_EQ( y(2), 23.0);
+
+  // test beta=0 with simulated NaN in uninitialized y
+  y(0) = NAN;
+  pressio::ops::elementwise_multiply(1., x, z, 0., y);
+  EXPECT_DOUBLE_EQ( y(0), 6.0);
+  EXPECT_DOUBLE_EQ( y(1), 12.0);
+  EXPECT_DOUBLE_EQ( y(2), 20.0);
 }

--- a/tests/functional_small/ops/ops_eigen_vector.cc
+++ b/tests/functional_small/ops/ops_eigen_vector.cc
@@ -295,7 +295,7 @@ TEST(ops_eigen, vector_elementwiseMultiply)
   EXPECT_DOUBLE_EQ( y(2), 23.0);
 
   // test beta=0 with simulated NaN in uninitialized y
-  y(0) = NAN;
+  y(0) = std::nan("0");
   pressio::ops::elementwise_multiply(1., x, z, 0., y);
   EXPECT_DOUBLE_EQ( y(0), 6.0);
   EXPECT_DOUBLE_EQ( y(1), 12.0);

--- a/tests/functional_small/ops/ops_epetra_level2.cc
+++ b/tests/functional_small/ops/ops_epetra_level2.cc
@@ -36,7 +36,7 @@ TEST_F(epetraMultiVectorGlobSize15Fixture, mv_prod_eigen_vector_beta0)
     a.setConstant(1.);
 
     Epetra_Vector y(*contigMap_);
-    y.PutScalar(NAN);
+    y.PutScalar(std::nan("0"));
     pressio::ops::product(::pressio::nontranspose{}, 1., *myMv_, a, 0., y);
 
     EXPECT_DOUBLE_EQ(y[0], 6.);

--- a/tests/functional_small/ops/ops_epetra_level2.cc
+++ b/tests/functional_small/ops/ops_epetra_level2.cc
@@ -24,6 +24,27 @@ TEST_F(epetraMultiVectorGlobSize15Fixture, mv_prod_eigen_vector)
     EXPECT_DOUBLE_EQ(y[3], 6.);
 }
 
+TEST_F(epetraMultiVectorGlobSize15Fixture, mv_prod_eigen_vector_beta0)
+{
+    for (int i=0; i<localSize_; ++i){
+     for (int j=0; j<numVecs_; ++j){
+        (*myMv_)[j][i] = (double)j;
+     }
+    }
+
+    Eigen::VectorXd a(numVecs_);
+    a.setConstant(1.);
+
+    Epetra_Vector y(*contigMap_);
+    y.PutScalar(NAN);
+    pressio::ops::product(::pressio::nontranspose{}, 1., *myMv_, a, 0., y);
+
+    EXPECT_DOUBLE_EQ(y[0], 6.);
+    EXPECT_DOUBLE_EQ(y[1], 6.);
+    EXPECT_DOUBLE_EQ(y[2], 6.);
+    EXPECT_DOUBLE_EQ(y[3], 6.);
+}
+
 TEST_F(epetraMultiVectorGlobSize15Fixture, mv_T_vector_storein_eigen_vector)
 {
     auto & myMv_h = *myMv_;

--- a/tests/functional_small/ops/ops_epetra_level3.cc
+++ b/tests/functional_small/ops/ops_epetra_level3.cc
@@ -51,7 +51,7 @@ TEST_F(epetraMultiVectorGlobSize15Fixture, mv_T_mv_storein_eigen_C_beta0)
     }
 
     Eigen::MatrixXd C(A.NumVectors(), B.NumVectors());
-    C.setConstant(NAN);
+    C.setConstant(std::nan("0"));
 
     // C = 0*NAN + 1.5 A^T B
     pressio::ops::product(pressio::transpose(), pressio::nontranspose(),
@@ -105,7 +105,7 @@ TEST_F(epetraMultiVectorGlobSize15Fixture, mv_T_self_storein_eigen_C_beta0)
     }
 
     Eigen::MatrixXd C(A.NumVectors(), A.NumVectors());
-    C.setConstant(NAN);
+    C.setConstant(std::nan("0"));
 
     // C = 0*NAN + 1.5 A^T A
     pressio::ops::product(pressio::transpose(), pressio::nontranspose(),

--- a/tests/functional_small/ops/ops_epetra_level3.cc
+++ b/tests/functional_small/ops/ops_epetra_level3.cc
@@ -20,11 +20,44 @@ TEST_F(epetraMultiVectorGlobSize15Fixture, mv_T_mv_storein_eigen_C)
     Eigen::MatrixXd C(A.NumVectors(), B.NumVectors());
     C.setConstant(0.);
 
-    // C = 1*C + 1.5 A^T B 
-    pressio::ops::product(pressio::transpose(), pressio::nontranspose(), 
+    // C = 1*C + 1.5 A^T B
+    pressio::ops::product(pressio::transpose(), pressio::nontranspose(),
         1.5, A, B, 1.0, C);
 
-    auto C2 = pressio::ops::product<Eigen::MatrixXd>(pressio::transpose(), pressio::nontranspose(), 
+    auto C2 = pressio::ops::product<Eigen::MatrixXd>(pressio::transpose(), pressio::nontranspose(),
+        1.5, A, B);
+
+    for (auto i=0; i<C.rows(); i++){
+        for (auto j=0; j<C.cols(); j++){
+            const auto gold = ac[i]*A.GlobalLength()*1.5*bc[j];
+            EXPECT_NEAR( C(i,j), gold, 1e-12);
+            EXPECT_NEAR( C2(i,j), gold, 1e-12);
+        }
+    }
+}
+
+TEST_F(epetraMultiVectorGlobSize15Fixture, mv_T_mv_storein_eigen_C_beta0)
+{
+    auto A = pressio::ops::clone(*myMv_);
+    std::array<double, 4> ac{1.,2.,3.,4.};
+    for (int i=0; i<A.NumVectors(); ++i) {
+      A(i)->PutScalar(ac[i]);
+    }
+
+    Epetra_MultiVector B(*contigMap_, 3);
+    std::array<double, 3> bc{1.2, 2.2, 3.2};
+    for (int i=0; i<3; ++i) {
+      B(i)->PutScalar(bc[i]);
+    }
+
+    Eigen::MatrixXd C(A.NumVectors(), B.NumVectors());
+    C.setConstant(NAN);
+
+    // C = 0*NAN + 1.5 A^T B
+    pressio::ops::product(pressio::transpose(), pressio::nontranspose(),
+        1.5, A, B, 0.0, C);
+
+    auto C2 = pressio::ops::product<Eigen::MatrixXd>(pressio::transpose(), pressio::nontranspose(),
         1.5, A, B);
 
     for (auto i=0; i<C.rows(); i++){
@@ -48,8 +81,35 @@ TEST_F(epetraMultiVectorGlobSize15Fixture, mv_T_self_storein_eigen_C)
     C.setConstant(0.);
 
     // C = 1*C + 1.5 A^T A
-    pressio::ops::product(pressio::transpose(), pressio::nontranspose(), 
+    pressio::ops::product(pressio::transpose(), pressio::nontranspose(),
         1.5, A, 1.0, C);
+
+    if(rank_==0){
+        std::cout << C << std::endl;
+    }
+
+    for (auto i=0; i<C.rows(); i++){
+        for (auto j=0; j<C.cols(); j++){
+            const auto gold = ac[i]*A.GlobalLength()*1.5*ac[j];
+            EXPECT_NEAR( C(i,j), gold, 1e-12);
+        }
+    }
+}
+
+TEST_F(epetraMultiVectorGlobSize15Fixture, mv_T_self_storein_eigen_C_beta0)
+{
+    auto A = pressio::ops::clone(*myMv_);
+    std::array<double, 4> ac{1.,2.,3.,4.};
+    for (int i=0; i<A.NumVectors(); ++i) {
+      A(i)->PutScalar(ac[i]);
+    }
+
+    Eigen::MatrixXd C(A.NumVectors(), A.NumVectors());
+    C.setConstant(NAN);
+
+    // C = 0*NAN + 1.5 A^T A
+    pressio::ops::product(pressio::transpose(), pressio::nontranspose(),
+        1.5, A, 0.0, C);
 
     if(rank_==0){
         std::cout << C << std::endl;

--- a/tests/functional_small/ops/ops_epetra_vector.cc
+++ b/tests/functional_small/ops/ops_epetra_vector.cc
@@ -313,7 +313,7 @@ TEST_F(epetraVectorGlobSize15Fixture, vector_elementwiseMultiply)
     }
 
     // test beta=0 with simulated NaN in uninitialized y
-    y[0] = NAN;
+    y[0] = std::nan("0");
     pressio::ops::elementwise_multiply(1., x,z, 0., y);
     for (int i=0; i<localSize_; ++i){
       EXPECT_DOUBLE_EQ(y[i], 6.);

--- a/tests/functional_small/ops/ops_epetra_vector.cc
+++ b/tests/functional_small/ops/ops_epetra_vector.cc
@@ -310,5 +310,12 @@ TEST_F(epetraVectorGlobSize15Fixture, vector_elementwiseMultiply)
     pressio::ops::elementwise_multiply(1., x,z, 2., y);
     for (int i=0; i<localSize_; ++i){
       EXPECT_DOUBLE_EQ(y[i], 8.);
-    }    
+    }
+
+    // test beta=0 with simulated NaN in uninitialized y
+    y[0] = NAN;
+    pressio::ops::elementwise_multiply(1., x,z, 0., y);
+    for (int i=0; i<localSize_; ++i){
+      EXPECT_DOUBLE_EQ(y[i], 6.);
+    }
 }

--- a/tests/functional_small/ops/ops_kokkos_level2.cc
+++ b/tests/functional_small/ops/ops_kokkos_level2.cc
@@ -16,7 +16,7 @@
   M_h(2,2) = 1.; \
   Kokkos::deep_copy(M, M_h); \
   Kokkos::View<double*> myR("myR", 3); \
-  myR(0) = NAN; /* simulate uninitialized Nan */ \
+  myR(0) = std::nan("0"); /* simulate uninitialized NaN */ \
   constexpr auto beta  = ::pressio::utils::Constants<double>::zero(); \
   constexpr auto alpha = ::pressio::utils::Constants<double>::one();  \
   pressio::ops::product(pressio::nontranspose(), alpha, M, VECIN, beta, myR); \
@@ -42,7 +42,7 @@
   M_h(3,2) = 4.; \
   Kokkos::deep_copy(M, M_h); \
   Kokkos::View<double*> myR("myR", 3); \
-  myR(0) = NAN; /* simulate uninitialized Nan */ \
+  myR(0) = std::nan("0"); /* simulate uninitialized NaN */ \
   constexpr auto beta  = ::pressio::utils::Constants<double>::zero(); \
   constexpr auto alpha = ::pressio::utils::Constants<double>::one();  \
   pressio::ops::product(pressio::transpose(), alpha, M, VECIN, beta, myR); \

--- a/tests/functional_small/ops/ops_kokkos_level2.cc
+++ b/tests/functional_small/ops/ops_kokkos_level2.cc
@@ -16,6 +16,7 @@
   M_h(2,2) = 1.; \
   Kokkos::deep_copy(M, M_h); \
   Kokkos::View<double*> myR("myR", 3); \
+  myR(0) = NAN; /* simulate uninitialized Nan */ \
   constexpr auto beta  = ::pressio::utils::Constants<double>::zero(); \
   constexpr auto alpha = ::pressio::utils::Constants<double>::one();  \
   pressio::ops::product(pressio::nontranspose(), alpha, M, VECIN, beta, myR); \
@@ -41,6 +42,7 @@
   M_h(3,2) = 4.; \
   Kokkos::deep_copy(M, M_h); \
   Kokkos::View<double*> myR("myR", 3); \
+  myR(0) = NAN; /* simulate uninitialized Nan */ \
   constexpr auto beta  = ::pressio::utils::Constants<double>::zero(); \
   constexpr auto alpha = ::pressio::utils::Constants<double>::one();  \
   pressio::ops::product(pressio::transpose(), alpha, M, VECIN, beta, myR); \

--- a/tests/functional_small/ops/ops_kokkos_level3.cc
+++ b/tests/functional_small/ops/ops_kokkos_level3.cc
@@ -21,7 +21,7 @@ using mat_t = Kokkos::View<double**>;
   M_h(3,2) = 2.; \
   Kokkos::deep_copy(M, M_h); \
   mat_t myR("MYR", 4,4);         \
-  myR(0, 0) = NAN; /* simulate uninitialized Nan */ \
+  myR(0, 0) = std::nan("0"); /* simulate uninitialized NaN */ \
   constexpr auto beta  = ::pressio::utils::Constants<double>::zero(); \
   constexpr auto alpha = ::pressio::utils::Constants<double>::one();  \
   pressio::ops::product(pressio::nontranspose(), pressio::nontranspose(), \
@@ -62,7 +62,7 @@ using mat_t = Kokkos::View<double**>;
   M_h(3,2) = 2.; \
   Kokkos::deep_copy(M, M_h); \
   mat_t myR("MYR", 3,3);         \
-  myR(0, 0) = NAN; /* simulate uninitialized Nan */ \
+  myR(0, 0) = std::nan("0"); /* simulate uninitialized NaN */ \
   constexpr auto beta  = ::pressio::utils::Constants<double>::zero(); \
   constexpr auto alpha = ::pressio::utils::Constants<double>::one();  \
   pressio::ops::product(pressio::transpose(), pressio::nontranspose(), \
@@ -96,7 +96,7 @@ using mat_t = Kokkos::View<double**>;
   M_h(3,2) = 2.; \
   Kokkos::deep_copy(M, M_h); \
   mat_t myR("MYR", 3,3);         \
-  myR(0, 0) = NAN; /* simulate uninitialized Nan */ \
+  myR(0, 0) = std::nan("0"); /* simulate uninitialized NaN */ \
   constexpr auto beta  = ::pressio::utils::Constants<double>::zero(); \
   constexpr auto alpha = ::pressio::utils::Constants<double>::one();  \
   pressio::ops::product(pressio::transpose(), pressio::nontranspose(), alpha, M, beta, myR); \

--- a/tests/functional_small/ops/ops_kokkos_level3.cc
+++ b/tests/functional_small/ops/ops_kokkos_level3.cc
@@ -21,6 +21,7 @@ using mat_t = Kokkos::View<double**>;
   M_h(3,2) = 2.; \
   Kokkos::deep_copy(M, M_h); \
   mat_t myR("MYR", 4,4);         \
+  myR(0, 0) = NAN; /* simulate uninitialized Nan */ \
   constexpr auto beta  = ::pressio::utils::Constants<double>::zero(); \
   constexpr auto alpha = ::pressio::utils::Constants<double>::one();  \
   pressio::ops::product(pressio::nontranspose(), pressio::nontranspose(), \
@@ -61,6 +62,7 @@ using mat_t = Kokkos::View<double**>;
   M_h(3,2) = 2.; \
   Kokkos::deep_copy(M, M_h); \
   mat_t myR("MYR", 3,3);         \
+  myR(0, 0) = NAN; /* simulate uninitialized Nan */ \
   constexpr auto beta  = ::pressio::utils::Constants<double>::zero(); \
   constexpr auto alpha = ::pressio::utils::Constants<double>::one();  \
   pressio::ops::product(pressio::transpose(), pressio::nontranspose(), \
@@ -94,6 +96,7 @@ using mat_t = Kokkos::View<double**>;
   M_h(3,2) = 2.; \
   Kokkos::deep_copy(M, M_h); \
   mat_t myR("MYR", 3,3);         \
+  myR(0, 0) = NAN; /* simulate uninitialized Nan */ \
   constexpr auto beta  = ::pressio::utils::Constants<double>::zero(); \
   constexpr auto alpha = ::pressio::utils::Constants<double>::one();  \
   pressio::ops::product(pressio::transpose(), pressio::nontranspose(), alpha, M, beta, myR); \

--- a/tests/functional_small/ops/ops_kokkos_vector.cc
+++ b/tests/functional_small/ops/ops_kokkos_vector.cc
@@ -329,7 +329,7 @@ TEST(ops_kokkos, vector_elementwiseMultiply)
   EXPECT_DOUBLE_EQ( y_h(2), 23.0);
 
   // test beta=0 with simulated NaN in uninitialized y
-  Kokkos::deep_copy(y, NAN);
+  Kokkos::deep_copy(y, std::nan("0"));
   pressio::ops::elementwise_multiply(1., x, z, 0., y);
   Kokkos::deep_copy(y_h, y);
   EXPECT_DOUBLE_EQ( y_h(0), 6.0);

--- a/tests/functional_small/ops/ops_kokkos_vector.cc
+++ b/tests/functional_small/ops/ops_kokkos_vector.cc
@@ -327,4 +327,12 @@ TEST(ops_kokkos, vector_elementwiseMultiply)
   EXPECT_DOUBLE_EQ( y_h(0), 7.0);
   EXPECT_DOUBLE_EQ( y_h(1), 14.0);
   EXPECT_DOUBLE_EQ( y_h(2), 23.0);
+
+  // test beta=0 with simulated NaN in uninitialized y
+  Kokkos::deep_copy(y, NAN);
+  pressio::ops::elementwise_multiply(1., x, z, 0., y);
+  Kokkos::deep_copy(y_h, y);
+  EXPECT_DOUBLE_EQ( y_h(0), 6.0);
+  EXPECT_DOUBLE_EQ( y_h(1), 12.0);
+  EXPECT_DOUBLE_EQ( y_h(2), 20.0);
 }

--- a/tests/functional_small/ops/ops_tpetra_block_level2.cc
+++ b/tests/functional_small/ops/ops_tpetra_block_level2.cc
@@ -39,7 +39,7 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
   KokkosBlas::fill(a, 1.);
 
   vec_t y(*contigMap_, blockSize_);
-  y.putScalar(NAN);
+  y.putScalar(std::nan("0"));
   pressio::ops::product(::pressio::nontranspose{}, 1., *myMv_, a, 0., y);
 
   auto y_h = y.getVectorView().getLocalViewHost(Tpetra::Access::ReadWriteStruct());
@@ -110,7 +110,7 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
   a.setConstant(1.);
 
   vec_t y(*contigMap_, blockSize_);
-  y.putScalar(NAN);
+  y.putScalar(std::nan("0"));
   pressio::ops::product(::pressio::nontranspose{}, 1., *myMv_, a, 0., y);
 
   auto y_h = y.getMultiVectorView().getLocalViewHost(Tpetra::Access::ReadWriteStruct());

--- a/tests/functional_small/ops/ops_tpetra_block_level3.cc
+++ b/tests/functional_small/ops/ops_tpetra_block_level3.cc
@@ -99,7 +99,7 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
   }
 
   Eigen::MatrixXd C(A.getNumVectors(), A.getNumVectors());
-  C.setConstant(NAN);
+  C.setConstant(std::nan("0"));
 
   // C = 0*NAN + 1.5 A^T A
   pressio::ops::product(pressio::transpose(),
@@ -161,7 +161,7 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
   }
 
   Kokkos::View<double**, Kokkos::LayoutLeft> C("C", A.getNumVectors(), A.getNumVectors());
-  Kokkos::deep_copy(C, NAN);
+  Kokkos::deep_copy(C, std::nan("0"));
 
   // C = 0*NAN + 1.5 A^T A
   pressio::ops::product(pressio::transpose(),
@@ -230,7 +230,7 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
   }
 
   Kokkos::View<double**, Kokkos::LayoutLeft> C("C", A.getNumVectors(), B.getNumVectors());
-  Kokkos::deep_copy(C, NAN);
+  Kokkos::deep_copy(C, std::nan("0"));
 
   // C = 0*NAN + 1.5 A^T B
   pressio::ops::product(pressio::transpose(),

--- a/tests/functional_small/ops/ops_tpetra_block_level3.cc
+++ b/tests/functional_small/ops/ops_tpetra_block_level3.cc
@@ -88,6 +88,35 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
     }
   }
 }
+
+TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
+       mv_T_self_storein_eigen_C_beta0)
+{
+  auto A = pressio::ops::clone(*myMv_);
+  std::array<double, 4> ac{1.,2.,3.,4.};
+  for (std::size_t i=0; i<A.getMultiVectorView().getNumVectors(); ++i) {
+    A.getMultiVectorView().getVectorNonConst(i)->putScalar(ac[i]);
+  }
+
+  Eigen::MatrixXd C(A.getNumVectors(), A.getNumVectors());
+  C.setConstant(NAN);
+
+  // C = 0*NAN + 1.5 A^T A
+  pressio::ops::product(pressio::transpose(),
+			pressio::nontranspose(),
+			1.5, A, 0.0, C);
+
+  if(rank_==0){
+    std::cout << C << std::endl;
+  }
+
+  for (auto i=0; i<C.rows(); i++){
+    for (auto j=0; j<C.cols(); j++){
+      const auto gold = ac[i]*A.getMultiVectorView().getGlobalLength()*1.5*ac[j];
+      EXPECT_NEAR( C(i,j), gold, 1e-12);
+    }
+  }
+}
 #endif
 
 
@@ -106,6 +135,38 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
   pressio::ops::product(pressio::transpose(),
 			pressio::nontranspose(),
 			1.5, A, 1.0, C);
+
+  auto C2 = pressio::ops::product<
+    Kokkos::View<double**, Kokkos::LayoutLeft>>(pressio::transpose(),
+						pressio::nontranspose(), 1.5, A);
+
+  auto C_h = Kokkos::create_mirror_view(C);
+  auto C2_h = Kokkos::create_mirror_view(C2);
+  for (std::size_t i=0; i<C.extent(0); i++){
+    for (std::size_t j=0; j<C.extent(1); j++){
+      const auto gold = ac[i]*A.getMultiVectorView().getGlobalLength()*1.5*ac[j];
+      EXPECT_NEAR( C_h(i,j), gold, 1e-12);
+      EXPECT_NEAR( C2_h(i,j), gold, 1e-12);
+    }
+  }
+}
+
+TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
+       mv_T_self_storein_kokkos_C_beta0)
+{
+  auto A = pressio::ops::clone(*myMv_);
+  std::array<double, 4> ac{1.,2.,3.,4.};
+  for (std::size_t i=0; i<A.getNumVectors(); ++i) {
+    A.getMultiVectorView().getVectorNonConst(i)->putScalar(ac[i]);
+  }
+
+  Kokkos::View<double**, Kokkos::LayoutLeft> C("C", A.getNumVectors(), A.getNumVectors());
+  Kokkos::deep_copy(C, NAN);
+
+  // C = 0*NAN + 1.5 A^T A
+  pressio::ops::product(pressio::transpose(),
+			pressio::nontranspose(),
+			1.5, A, 0.0, C);
 
   auto C2 = pressio::ops::product<
     Kokkos::View<double**, Kokkos::LayoutLeft>>(pressio::transpose(),
@@ -143,6 +204,38 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
   pressio::ops::product(pressio::transpose(),
 			pressio::nontranspose(),
 			1.5, A, B, 1.0, C);
+
+  auto C_h = Kokkos::create_mirror_view(C);
+  for (std::size_t i=0; i<C.extent(0); i++){
+    for (std::size_t j=0; j<C.extent(1); j++){
+      const auto gold = ac[i]*A.getMultiVectorView().getGlobalLength()*1.5*bc[j];
+      EXPECT_NEAR( C_h(i,j), gold, 1e-12);
+    }
+  }
+}
+
+TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
+       mv_T_mv_storein_kokkos_C_beta0)
+{
+  auto A = pressio::ops::clone(*myMv_);
+  std::array<double, 4> ac{1.,2.,3.,4.};
+  for (std::size_t i=0; i<A.getNumVectors(); ++i) {
+    A.getMultiVectorView().getVectorNonConst(i)->putScalar(ac[i]);
+  }
+
+  mvec_t B(*contigMap_, blockSize_, 3);
+  std::array<double, 3> bc{1.2, 2.2, 3.2};
+  for (int i=0; i<3; ++i) {
+    B.getMultiVectorView().getVectorNonConst(i)->putScalar(bc[i]);
+  }
+
+  Kokkos::View<double**, Kokkos::LayoutLeft> C("C", A.getNumVectors(), B.getNumVectors());
+  Kokkos::deep_copy(C, NAN);
+
+  // C = 0*NAN + 1.5 A^T B
+  pressio::ops::product(pressio::transpose(),
+			pressio::nontranspose(),
+			1.5, A, B, 0.0, C);
 
   auto C_h = Kokkos::create_mirror_view(C);
   for (std::size_t i=0; i<C.extent(0); i++){

--- a/tests/functional_small/ops/ops_tpetra_block_vector.cc
+++ b/tests/functional_small/ops/ops_tpetra_block_vector.cc
@@ -299,7 +299,7 @@ TEST_F(tpetraBlockVectorGlobSize15BlockSize5Fixture, vector_elementwiseMultiply)
   // test beta=0 with simulated NaN in uninitialized y
   pressio::ops::fill(x, 3.);
   pressio::ops::fill(z, 2.);
-  pressio::ops::fill(y, NAN);
+  pressio::ops::fill(y, std::nan("0"));
   pressio::ops::elementwise_multiply(2., x,z, 0., y);
   auto y_h = y.getVectorView().getLocalViewHost(Tpetra::Access::ReadWriteStruct());
   for (int i=0; i<localSize_*blockSize_; ++i){

--- a/tests/functional_small/ops/ops_tpetra_block_vector.cc
+++ b/tests/functional_small/ops/ops_tpetra_block_vector.cc
@@ -5,7 +5,7 @@
 TEST_F(tpetraBlockVectorGlobSize15BlockSize5Fixture, vector_clone)
 {
   auto a = pressio::ops::clone(*myVector_);
-  ASSERT_TRUE(a.getVectorView().getLocalViewDevice(Tpetra::Access::ReadWriteStruct()).data() 
+  ASSERT_TRUE(a.getVectorView().getLocalViewDevice(Tpetra::Access::ReadWriteStruct()).data()
     != myVector_->getVectorView().getLocalViewDevice(Tpetra::Access::ReadWriteStruct()).data());
 
   auto a_h = a.getVectorView().getLocalViewHost(Tpetra::Access::ReadWriteStruct());
@@ -295,4 +295,15 @@ TEST_F(tpetraBlockVectorGlobSize15BlockSize5Fixture, vector_elementwiseMultiply)
   for (int i=0; i<localSize_*blockSize_; ++i){
     EXPECT_DOUBLE_EQ(z_h(i,0), 18.);
   }
+
+  // test beta=0 with simulated NaN in uninitialized y
+  pressio::ops::fill(x, 3.);
+  pressio::ops::fill(z, 2.);
+  pressio::ops::fill(y, NAN);
+  pressio::ops::elementwise_multiply(2., x,z, 0., y);
+  auto y_h = y.getVectorView().getLocalViewHost(Tpetra::Access::ReadWriteStruct());
+  for (int i=0; i<localSize_*blockSize_; ++i){
+    EXPECT_DOUBLE_EQ(y_h(i,0), 12);
+  }
+
 }

--- a/tests/functional_small/ops/ops_tpetra_level2.cc
+++ b/tests/functional_small/ops/ops_tpetra_level2.cc
@@ -25,6 +25,29 @@ TEST_F(tpetraMultiVectorGlobSize15Fixture, mv_prod_kokkos_vector)
     EXPECT_DOUBLE_EQ(y_h(3,0), 6.);
 }
 
+TEST_F(tpetraMultiVectorGlobSize15Fixture, mv_prod_kokkos_vector_beta0)
+{
+    auto myMv_h = myMv_->getLocalViewHost(Tpetra::Access::ReadWriteStruct());
+    for (int i=0; i<localSize_; ++i){
+     for (int j=0; j<numVecs_; ++j){
+        myMv_h(i,j) = (double)j;
+     }
+    }
+
+    Kokkos::View<double*> a("a", numVecs_);
+    KokkosBlas::fill(a, 1.);
+
+    vec_t y(contigMap_);
+    y.putScalar(NAN);
+    pressio::ops::product(::pressio::nontranspose{}, 1., *myMv_, a, 0., y);
+
+    auto y_h = y.getLocalViewHost(Tpetra::Access::ReadWriteStruct());
+    EXPECT_DOUBLE_EQ(y_h(0,0), 6.);
+    EXPECT_DOUBLE_EQ(y_h(1,0), 6.);
+    EXPECT_DOUBLE_EQ(y_h(2,0), 6.);
+    EXPECT_DOUBLE_EQ(y_h(3,0), 6.);
+}
+
 TEST_F(tpetraMultiVectorGlobSize15Fixture, mv_T_vector_storein_kokkos_vector)
 {
     auto myMv_h = myMv_->getLocalViewHost(Tpetra::Access::ReadWriteStruct());
@@ -65,6 +88,29 @@ TEST_F(tpetraMultiVectorGlobSize15Fixture, mv_prod_eigen_vector)
     vec_t y(contigMap_);
     y.putScalar(0.);
     pressio::ops::product(::pressio::nontranspose{}, 1., *myMv_, a, 1., y);
+
+    auto y_h = y.getLocalViewHost(Tpetra::Access::ReadWriteStruct());
+    EXPECT_DOUBLE_EQ(y_h(0,0), 6.);
+    EXPECT_DOUBLE_EQ(y_h(1,0), 6.);
+    EXPECT_DOUBLE_EQ(y_h(2,0), 6.);
+    EXPECT_DOUBLE_EQ(y_h(3,0), 6.);
+}
+
+TEST_F(tpetraMultiVectorGlobSize15Fixture, mv_prod_eigen_vector_beta0)
+{
+    auto myMv_h = myMv_->getLocalViewHost(Tpetra::Access::ReadWriteStruct());
+    for (int i=0; i<localSize_; ++i){
+     for (int j=0; j<numVecs_; ++j){
+        myMv_h(i,j) = (double)j;
+     }
+    }
+
+    Eigen::VectorXd a(numVecs_);
+    a.setConstant(1.);
+
+    vec_t y(contigMap_);
+    y.putScalar(NAN);
+    pressio::ops::product(::pressio::nontranspose{}, 1., *myMv_, a, 0., y);
 
     auto y_h = y.getLocalViewHost(Tpetra::Access::ReadWriteStruct());
     EXPECT_DOUBLE_EQ(y_h(0,0), 6.);

--- a/tests/functional_small/ops/ops_tpetra_level2.cc
+++ b/tests/functional_small/ops/ops_tpetra_level2.cc
@@ -38,7 +38,7 @@ TEST_F(tpetraMultiVectorGlobSize15Fixture, mv_prod_kokkos_vector_beta0)
     KokkosBlas::fill(a, 1.);
 
     vec_t y(contigMap_);
-    y.putScalar(NAN);
+    y.putScalar(std::nan("0"));
     pressio::ops::product(::pressio::nontranspose{}, 1., *myMv_, a, 0., y);
 
     auto y_h = y.getLocalViewHost(Tpetra::Access::ReadWriteStruct());
@@ -109,7 +109,7 @@ TEST_F(tpetraMultiVectorGlobSize15Fixture, mv_prod_eigen_vector_beta0)
     a.setConstant(1.);
 
     vec_t y(contigMap_);
-    y.putScalar(NAN);
+    y.putScalar(std::nan("0"));
     pressio::ops::product(::pressio::nontranspose{}, 1., *myMv_, a, 0., y);
 
     auto y_h = y.getLocalViewHost(Tpetra::Access::ReadWriteStruct());

--- a/tests/functional_small/ops/ops_tpetra_level3.cc
+++ b/tests/functional_small/ops/ops_tpetra_level3.cc
@@ -49,7 +49,7 @@ TEST_F(tpetraMultiVectorGlobSize15Fixture, mv_T_mv_storein_eigen_C_beta0)
     }
 
     Eigen::MatrixXd C(A.getNumVectors(), B.getNumVectors());
-    C.setConstant(NAN);
+    C.setConstant(std::nan("0"));
 
     // C = 1*C + 1.5 A^T B
     pressio::ops::product(
@@ -103,7 +103,7 @@ TEST_F(tpetraMultiVectorGlobSize15Fixture, mv_T_self_storein_eigen_C_beta0)
     }
 
     Eigen::MatrixXd C(A.getNumVectors(), A.getNumVectors());
-    C.setConstant(NAN);
+    C.setConstant(std::nan("0"));
 
     // C = 0*NAN + 1.5 A^T A
     pressio::ops::product(
@@ -225,7 +225,7 @@ TEST_F(tpetraMultiVectorGlobSize15Fixture, mv_T_self_storein_kokkos_C_beta0)
     }
 
     Kokkos::View<double**, Kokkos::LayoutLeft> C("C", A.getNumVectors(), A.getNumVectors());
-    Kokkos::deep_copy(C, NAN);
+    Kokkos::deep_copy(C, std::nan("0"));
 
     // C = 0*NAN + 1.5 A^T A
     pressio::ops::product(
@@ -294,7 +294,7 @@ TEST_F(tpetraMultiVectorGlobSize15Fixture, mv_T_mv_storein_kokkos_C_beta0)
     }
 
     Kokkos::View<double**, Kokkos::LayoutLeft> C("C", A.getNumVectors(), B.getNumVectors());
-    Kokkos::deep_copy(C, NAN);
+    Kokkos::deep_copy(C, std::nan("0"));
 
     // C = 0*NAN + 1.5 A^T B
     pressio::ops::product(

--- a/tests/functional_small/ops/ops_tpetra_level3.cc
+++ b/tests/functional_small/ops/ops_tpetra_level3.cc
@@ -34,6 +34,37 @@ TEST_F(tpetraMultiVectorGlobSize15Fixture, mv_T_mv_storein_eigen_C)
     }
 }
 
+TEST_F(tpetraMultiVectorGlobSize15Fixture, mv_T_mv_storein_eigen_C_beta0)
+{
+    auto A = pressio::ops::clone(*myMv_);
+    std::array<double, 4> ac{1.,2.,3.,4.};
+    for (std::size_t i=0; i<A.getNumVectors(); ++i) {
+      A.getVectorNonConst(i)->putScalar(ac[i]);
+    }
+
+    mvec_t B(contigMap_, 3);
+    std::array<double, 3> bc{1.2, 2.2, 3.2};
+    for (int i=0; i<3; ++i) {
+      B.getVectorNonConst(i)->putScalar(bc[i]);
+    }
+
+    Eigen::MatrixXd C(A.getNumVectors(), B.getNumVectors());
+    C.setConstant(NAN);
+
+    // C = 1*C + 1.5 A^T B
+    pressio::ops::product(
+        pressio::transpose(),
+        pressio::nontranspose(),
+        1.5, A, B, 0.0, C);
+
+    for (auto i=0; i<C.rows(); i++){
+        for (auto j=0; j<C.cols(); j++){
+            const auto gold = ac[i]*A.getGlobalLength()*1.5*bc[j];
+            EXPECT_NEAR( C(i,j), gold, 1e-12);
+        }
+    }
+}
+
 TEST_F(tpetraMultiVectorGlobSize15Fixture, mv_T_self_storein_eigen_C)
 {
     auto A = pressio::ops::clone(*myMv_);
@@ -50,6 +81,35 @@ TEST_F(tpetraMultiVectorGlobSize15Fixture, mv_T_self_storein_eigen_C)
         pressio::transpose(),
         pressio::nontranspose(),
         1.5, A, 1.0, C);
+
+    if(rank_==0){
+        std::cout << C << std::endl;
+    }
+
+    for (auto i=0; i<C.rows(); i++){
+        for (auto j=0; j<C.cols(); j++){
+            const auto gold = ac[i]*A.getGlobalLength()*1.5*ac[j];
+            EXPECT_NEAR( C(i,j), gold, 1e-12);
+        }
+    }
+}
+
+TEST_F(tpetraMultiVectorGlobSize15Fixture, mv_T_self_storein_eigen_C_beta0)
+{
+    auto A = pressio::ops::clone(*myMv_);
+    std::array<double, 4> ac{1.,2.,3.,4.};
+    for (std::size_t i=0; i<A.getNumVectors(); ++i) {
+      A.getVectorNonConst(i)->putScalar(ac[i]);
+    }
+
+    Eigen::MatrixXd C(A.getNumVectors(), A.getNumVectors());
+    C.setConstant(NAN);
+
+    // C = 0*NAN + 1.5 A^T A
+    pressio::ops::product(
+        pressio::transpose(),
+        pressio::nontranspose(),
+        1.5, A, 0.0, C);
 
     if(rank_==0){
         std::cout << C << std::endl;
@@ -156,6 +216,37 @@ TEST_F(tpetraMultiVectorGlobSize15Fixture, mv_T_self_storein_kokkos_C)
     }
 }
 
+TEST_F(tpetraMultiVectorGlobSize15Fixture, mv_T_self_storein_kokkos_C_beta0)
+{
+    auto A = pressio::ops::clone(*myMv_);
+    std::array<double, 4> ac{1.,2.,3.,4.};
+    for (std::size_t i=0; i<A.getNumVectors(); ++i) {
+      A.getVectorNonConst(i)->putScalar(ac[i]);
+    }
+
+    Kokkos::View<double**, Kokkos::LayoutLeft> C("C", A.getNumVectors(), A.getNumVectors());
+    Kokkos::deep_copy(C, NAN);
+
+    // C = 0*NAN + 1.5 A^T A
+    pressio::ops::product(
+        pressio::transpose(),
+        pressio::nontranspose(),
+        1.5, A, 0.0, C);
+
+    auto C2 = pressio::ops::product<Kokkos::View<double**, Kokkos::LayoutLeft>>(
+        pressio::transpose(), pressio::nontranspose(), 1.5, A);
+
+    auto C_h = Kokkos::create_mirror_view(C);
+    auto C2_h = Kokkos::create_mirror_view(C2);
+    for (std::size_t i=0; i<C.extent(0); i++){
+        for (std::size_t j=0; j<C.extent(1); j++){
+            const auto gold = ac[i]*A.getGlobalLength()*1.5*ac[j];
+            EXPECT_NEAR( C_h(i,j), gold, 1e-12);
+            EXPECT_NEAR( C2_h(i,j), gold, 1e-12);
+        }
+    }
+}
+
 
 TEST_F(tpetraMultiVectorGlobSize15Fixture, mv_T_mv_storein_kokkos_C)
 {
@@ -178,6 +269,38 @@ TEST_F(tpetraMultiVectorGlobSize15Fixture, mv_T_mv_storein_kokkos_C)
         pressio::transpose(),
         pressio::nontranspose(),
         1.5, A, B, 1.0, C);
+
+    auto C_h = Kokkos::create_mirror_view(C);
+    for (std::size_t i=0; i<C.extent(0); i++){
+        for (std::size_t j=0; j<C.extent(1); j++){
+            const auto gold = ac[i]*A.getGlobalLength()*1.5*bc[j];
+            EXPECT_NEAR( C_h(i,j), gold, 1e-12);
+        }
+    }
+}
+
+TEST_F(tpetraMultiVectorGlobSize15Fixture, mv_T_mv_storein_kokkos_C_beta0)
+{
+    auto A = pressio::ops::clone(*myMv_);
+    std::array<double, 4> ac{1.,2.,3.,4.};
+    for (std::size_t i=0; i<A.getNumVectors(); ++i) {
+      A.getVectorNonConst(i)->putScalar(ac[i]);
+    }
+
+    mvec_t B(contigMap_, 3);
+    std::array<double, 3> bc{1.2, 2.2, 3.2};
+    for (int i=0; i<3; ++i) {
+      B.getVectorNonConst(i)->putScalar(bc[i]);
+    }
+
+    Kokkos::View<double**, Kokkos::LayoutLeft> C("C", A.getNumVectors(), B.getNumVectors());
+    Kokkos::deep_copy(C, NAN);
+
+    // C = 0*NAN + 1.5 A^T B
+    pressio::ops::product(
+        pressio::transpose(),
+        pressio::nontranspose(),
+        1.5, A, B, 0.0, C);
 
     auto C_h = Kokkos::create_mirror_view(C);
     for (std::size_t i=0; i<C.extent(0); i++){

--- a/tests/functional_small/ops/ops_tpetra_vector.cc
+++ b/tests/functional_small/ops/ops_tpetra_vector.cc
@@ -427,7 +427,7 @@ TEST(ops_tpetra, vector_elementwiseMultiply)
   pressio::ops::elementwise_multiply(1., x, b, 1., c);
   auto ch = c.getLocalViewHost(Tpetra::Access::ReadWriteStruct());
   vec_t c0(map);
-  pressio::ops::fill(c0, NAN); // test beta=0 with simulated NaN in uninitialized c
+  pressio::ops::fill(c0, std::nan("0")); // test beta=0 with simulated NaN in uninitialized c
   pressio::ops::elementwise_multiply(1., x, b, 0., c0);
   auto ch0 = c0.getLocalViewHost(Tpetra::Access::ReadWriteStruct());
 

--- a/tests/functional_small/ops/ops_tpetra_vector.cc
+++ b/tests/functional_small/ops/ops_tpetra_vector.cc
@@ -422,9 +422,14 @@ TEST(ops_tpetra, vector_elementwiseMultiply)
 
   // 3. compute ewise multiply
   vec_t c(map);
-  pressio::ops::fill(c, 0.);
-  pressio::ops::elementwise_multiply(1., x, b, 0., c);
+  const double offset = -5.0;
+  pressio::ops::fill(c, offset);
+  pressio::ops::elementwise_multiply(1., x, b, 1., c);
   auto ch = c.getLocalViewHost(Tpetra::Access::ReadWriteStruct());
+  vec_t c0(map);
+  pressio::ops::fill(c0, NAN); // test beta=0 with simulated NaN in uninitialized c
+  pressio::ops::elementwise_multiply(1., x, b, 0., c0);
+  auto ch0 = c0.getLocalViewHost(Tpetra::Access::ReadWriteStruct());
 
   // 5. check correctness
   Eigen::VectorXd g(numGlobalEntries);
@@ -436,6 +441,7 @@ TEST(ops_tpetra, vector_elementwiseMultiply)
   g(5) = 35.;
 
   for (int i=0; i<numLocalEntries; ++i){
-    EXPECT_DOUBLE_EQ(ch(i,0), g(shift+i));
+    EXPECT_DOUBLE_EQ(ch0(i,0), g(shift+i));
+    EXPECT_DOUBLE_EQ(ch(i,0), g(shift+i) + offset);
   }
 }


### PR DESCRIPTION
This PR fixes `NaN` injection bug (detected on https://github.com/Pressio/pressio/pull/337#issuecomment-1057999321) in `pressio::ops::product()` and `pressio::ops::elementwise_multiply()` (no other ops seem to be affected).

With the bug in place we'll get `NaN` instead of expected results when output variable is initialized with `NaN` and `beta=0` is set for the operation, e.g. `y = alpha * x * z + beta * y` with `beta=0` and `y=NaN`. The solution proposed here is to skip the update alltogether if `beta==0`.

Tests for these ops are expanded to cover both `beta==0` and `beta!=0` execution paths, with the first one setting `NaN` in the result variable to simulate it's uninitialized state.

