### PR TITLE
#413: Add documentation for abs op

### DIFF
--- a/docs/source/components/ops.rst
+++ b/docs/source/components/ops.rst
@@ -8,5 +8,6 @@ Public namespace: ``pressio::ops``
 .. toctree::
    :maxdepth: 1
 
+   ops/abs
    ops/clone
    ops/fill

--- a/docs/source/components/ops/abs.rst
+++ b/docs/source/components/ops/abs.rst
@@ -20,24 +20,26 @@ API
 Parameters
 ----------
 
-* ``destination``: the object to store absolute value
+* ``destination``: the object to write to
 
-* ``source``: the object to calculate abs
+* ``source``: the object whose elements are used to compute the absolute value of
 
 Constraints
 ~~~~~~~~~~~
 
 - ``T1`` and ``T2`` must be:
 
+  - a Pressio expression, e.g., span, operating on an Eigen object or Kokkos rank-1 object or
+
   - an Eigen vector, i.e. ``pressio::is_vector_eigen<T>::value`` or
 
-  - a epetra vector, i.e. ``pressio::is_vector_epetra<T>::value`` or
+  - an Epetra vector, i.e. ``pressio::is_vector_epetra<T>::value`` or
 
   - a Kokkos rank-1 view, i.e. ``pressio::is_vector_kokkos<T>::value`` or
 
-  - a tpetra vector, i.e. ``pressio::is_vector_tpetra<T>::value`` or
+  - a Tpetra vector, i.e. ``pressio::is_vector_tpetra<T>::value`` or
 
-  - a tpetra block vector, i.e. ``pressio::is_vector_tpetra_block<T>::value``
+  - a Tpetra block vector, i.e. ``pressio::is_vector_tpetra_block<T>::value``
 
 
 Mandates
@@ -58,7 +60,9 @@ None
 Effects
 ~~~~~~~
 
-:red:`finish`
+- Overwrite each element of ``destination`` with abs value of ``source``.
+
+- This is a blocking operation, i.e. the kernel completes before returning.
 
 Postconditions
 ~~~~~~~~~~~~~~

--- a/docs/source/components/ops/abs.rst
+++ b/docs/source/components/ops/abs.rst
@@ -1,0 +1,66 @@
+.. include:: ../../mydefs.rst
+
+``abs``
+========
+
+Header: ``<pressio/ops.hpp>``
+
+API
+---
+
+.. code-block:: cpp
+
+  namespace pressio { namespace ops{
+
+  template <class T1, class T2>
+  void abs(T1 & destination, const T2 & source);
+
+  }} // end namespace pressio::ops
+
+Parameters
+----------
+
+* ``destination``: the object to store absolute value
+
+* ``source``: the object to calculate abs
+
+Constraints
+~~~~~~~~~~~
+
+- ``T1`` and ``T2`` must be:
+
+  - an Eigen vector, i.e. ``pressio::is_vector_eigen<T>::value`` or
+
+  - a epetra vector, i.e. ``pressio::is_vector_epetra<T>::value`` or
+
+  - a Kokkos rank-1 view, i.e. ``pressio::is_vector_kokkos<T>::value`` or
+
+  - a tpetra vector, i.e. ``pressio::is_vector_tpetra<T>::value`` or
+
+  - a tpetra block vector, i.e. ``pressio::is_vector_tpetra_block<T>::value``
+
+
+Mandates
+~~~~~~~~
+
+:red:`finish`
+
+Preconditions
+~~~~~~~~~~~~~
+
+:red:`finish`
+
+Return value
+~~~~~~~~~~~~
+
+None
+
+Effects
+~~~~~~~
+
+:red:`finish`
+
+Postconditions
+~~~~~~~~~~~~~~
+
+:red:`finish`


### PR DESCRIPTION
Related to #413 

This PR adds documentation page for abs op.

[Updated] Page:
![Zrzut ekranu 2022-09-26 o 12 02 06](https://user-images.githubusercontent.com/7249519/192249303-75ba6cfa-154f-4647-9b9b-fb8dadc1c8b2.jpg)
