### PR TITLE
#413: Add documentation for add_to_diagonal op

### DIFF
--- a/docs/source/components/ops.rst
+++ b/docs/source/components/ops.rst
@@ -8,5 +8,7 @@ Public namespace: ``pressio::ops``
 .. toctree::
    :maxdepth: 1
 
+   ops/abs
+   ops/add_to_diagonal
    ops/clone
    ops/fill

--- a/docs/source/components/ops/add_to_diagonal.rst
+++ b/docs/source/components/ops/add_to_diagonal.rst
@@ -1,0 +1,62 @@
+.. include:: ../../mydefs.rst
+
+``add_to_diagonal``
+===================
+
+Header: ``<pressio/ops.hpp>``
+
+API
+---
+
+.. code-block:: cpp
+
+  namespace pressio { namespace ops{
+
+  template <class T, class ScalarType>
+  void add_to_diagonal(T & out, const ScalarType & value);
+
+  }} // end namespace pressio::ops
+
+Parameters
+----------
+
+* ``out``: the object to write to
+
+* ``value``: the value to be added to diagonal values of ``out``
+
+Constraints
+~~~~~~~~~~~
+
+- ``T`` must be:
+
+  - an Eigen matrix object, ``pressio::is_dense_matrix_eigen<T>::value`` or
+    ``pressio::is_sparse_matrix_eigen<T>::value``
+
+- ``ScalarType`` must be convertible to ``pressio::Traits<T>::scalar_type``
+
+Mandates
+~~~~~~~~
+
+:red:`finish`
+
+Preconditions
+~~~~~~~~~~~~~
+
+:red:`finish`
+
+Return value
+~~~~~~~~~~~~
+
+None
+
+Effects
+~~~~~~~
+
+- Adds value of ``value`` parameter to each diagonal field in the matrix.
+
+- This is a blocking operation, i.e. the kernel completes before returning.
+
+Postconditions
+~~~~~~~~~~~~~~
+
+:red:`finish`


### PR DESCRIPTION
Relates to #413 

![add_to_diagonal](https://user-images.githubusercontent.com/7249519/192468605-290312af-ab99-4712-82af-199eb099d570.jpg)
