### PR TITLE
Review `typedef` detection predicates

### DIFF
--- a/include/pressio/type_traits/nested_typedef_detection.hpp
+++ b/include/pressio/type_traits/nested_typedef_detection.hpp
@@ -59,40 +59,25 @@ namespace pressio{
   std::enable_if_t< !std::is_void<typename T::NAME##_type>::value > \
   > : std::true_type{};\
 
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(scalar)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(fom_state)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(full_state)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(reduced_state)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(state)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(time)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(velocity)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(right_hand_side)
+PRESSIO_IMPL_HAS_NESTED_TYPEDEF(scalar)            // usage: generic concepts
+PRESSIO_IMPL_HAS_NESTED_TYPEDEF(jacobian)          // usage: ode,      solvers_nonlinear
+PRESSIO_IMPL_HAS_NESTED_TYPEDEF(residual)          // usage: ode, rom, solvers_nonlinear
+PRESSIO_IMPL_HAS_NESTED_TYPEDEF(right_hand_side)   // usage: ode, rom
+PRESSIO_IMPL_HAS_NESTED_TYPEDEF(discrete_residual) // usage: ode, rom
+PRESSIO_IMPL_HAS_NESTED_TYPEDEF(state)             // usage: ode, rom, solvers_nonlinear
+// usage: ode
 PRESSIO_IMPL_HAS_NESTED_TYPEDEF(mass_matrix)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(residual)
+PRESSIO_IMPL_HAS_NESTED_TYPEDEF(discrete_jacobian)
 PRESSIO_IMPL_HAS_NESTED_TYPEDEF(independent_variable)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(communicator)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(ordinal)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(local_ordinal)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(global_ordinal)
+// usage: solvers_nonlinear
 PRESSIO_IMPL_HAS_NESTED_TYPEDEF(matrix)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(jacobian)
 PRESSIO_IMPL_HAS_NESTED_TYPEDEF(hessian)
 PRESSIO_IMPL_HAS_NESTED_TYPEDEF(gradient)
 PRESSIO_IMPL_HAS_NESTED_TYPEDEF(residual_norm)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(data_map)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(discrete_residual)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(discrete_time_residual)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(discrete_time_jacobian)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(discrete_jacobian)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(dense_matrix)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(manifold_tangent)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(basis)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(operand)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(result)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(residual_operand)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(jacobian_action_operand)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(right_hand_side_operand)
-PRESSIO_IMPL_HAS_NESTED_TYPEDEF(offset)
+// usage: rom
+PRESSIO_IMPL_HAS_NESTED_TYPEDEF(time)
+PRESSIO_IMPL_HAS_NESTED_TYPEDEF(full_state)
+PRESSIO_IMPL_HAS_NESTED_TYPEDEF(reduced_state)
 PRESSIO_IMPL_HAS_NESTED_TYPEDEF(basis_matrix)
 
 }//end namespace

--- a/tests/functional_small/type_traits/detect_typedefs.cc
+++ b/tests/functional_small/type_traits/detect_typedefs.cc
@@ -15,22 +15,22 @@ namespace pressio { namespace testing {
 TEST(type_traits, typedef_detect)
 {
   CHECK(T1, scalar_type);
-  CHECK(T2, ordinal_type);
-  CHECK(T3, local_ordinal_type);
-  CHECK(T4, global_ordinal_type);
-  CHECK(T5, data_map_type);
-  CHECK(T6, communicator_type);
-  CHECK(T7, fom_state_type);
-  CHECK(T8, velocity_type);
+  CHECK(T2, state_type);
+  CHECK(T3, full_state_type);
+  CHECK(T4, reduced_state_type);
+  CHECK(T5, basis_matrix_type);
+  CHECK(T6, mass_matrix_type);
+  CHECK(T7, independent_variable_type);
+  CHECK(T8, time_type);
   CHECK(T9, residual_type);
   CHECK(T10, matrix_type);
   CHECK(T11, jacobian_type);
   CHECK(T12, hessian_type);
   CHECK(T13, gradient_type);
-  CHECK(T14, discrete_time_residual_type);
-  CHECK(T15, discrete_time_jacobian_type);
-  CHECK(T16, dense_matrix_type);
-  CHECK(T17, velocity_type);
+  CHECK(T14, discrete_jacobian_type);
+  CHECK(T15, discrete_residual_type);
+  CHECK(T16, right_hand_side_type);
+  CHECK(T17, residual_norm_type);
 }
 
 }} // pressio::testing


### PR DESCRIPTION
This PR removes unused `has_*_typedef` detection predicates and supplies the missing ones in the unit test.