### PR TITLE
tests: fix floating point comparisons

### DIFF
--- a/tests/functional_small/ode_steppers/ode_all_explicit_schemes_fixed_mass_matrix_correctness_eigen.cc
+++ b/tests/functional_small/ode_steppers/ode_all_explicit_schemes_fixed_mass_matrix_correctness_eigen.cc
@@ -86,7 +86,7 @@ struct MyApp2NoMM
     rhs = rhs_.at(++count1);
     // we want to make sure we have the correct time
     for (int i=0; i<rhs.size(); ++i){
-      EXPECT_DOUBLE_EQ(rhs(i), evaltime);
+      EXPECT_NEAR(rhs(i), evaltime, 1e-15);
     }
 
     rhs = uniqueMM_.inverse()*rhs;

--- a/tests/functional_small/ode_steppers/ode_all_explicit_schemes_varying_mass_matrix_correctness_eigen.cc
+++ b/tests/functional_small/ode_steppers/ode_all_explicit_schemes_varying_mass_matrix_correctness_eigen.cc
@@ -88,7 +88,7 @@ struct MyApp2NoMM
     rhs = rhs_.at(++count1);
     // we want to make sure we have the correct time
     for (int i=0; i<rhs.size(); ++i){
-      EXPECT_DOUBLE_EQ(rhs(i), evaltime);
+      EXPECT_NEAR(rhs(i), evaltime, 1e-15);
     }
 
     auto M = createMassMatrix();
@@ -110,7 +110,7 @@ private:
   {
     M = matrices_.at(++count2);
     for (int i=0; i<M.rows(); ++i){
-      EXPECT_DOUBLE_EQ(M(i,i), evaltime);
+      EXPECT_NEAR(M(i,i), evaltime, 1e-15);
     }
   };
 };

--- a/tests/functional_small/ode_steppers/ode_bdf1_simple_correctness_eigen.cc
+++ b/tests/functional_small/ode_steppers/ode_bdf1_simple_correctness_eigen.cc
@@ -58,9 +58,9 @@ TEST(ode, implicit_bdf1_custom_policy)
   std::cout << std::setprecision(14) << y << "\n";
 
   problemObj.analyticAdvanceBackEulerNSteps(dt, nSteps.get());
-  EXPECT_DOUBLE_EQ(y(0), problemObj.y(0));
-  EXPECT_DOUBLE_EQ(y(1), problemObj.y(1));
-  EXPECT_DOUBLE_EQ(y(2), problemObj.y(2));
+  EXPECT_NEAR(y(0), problemObj.y(0), 1e-15);
+  EXPECT_NEAR(y(1), problemObj.y(1), 1e-15);
+  EXPECT_NEAR(y(2), problemObj.y(2), 1e-15);
 }
 
 

--- a/tests/functional_small/ode_steppers/ode_bdf2_simple_correctness_eigen.cc
+++ b/tests/functional_small/ode_steppers/ode_bdf2_simple_correctness_eigen.cc
@@ -28,9 +28,9 @@ TEST(ode, implicit_bdf2_policy_default_created)
   problemObj.analyticAdvanceBackEulerNSteps(dt, 1);
   problemObj.analyticAdvanceBDF2NSteps(dt, 3);
   std::cout << std::setprecision(14) << problemObj.y << "\n";
-  EXPECT_DOUBLE_EQ(y(0), problemObj.y(0));
-  EXPECT_DOUBLE_EQ(y(1), problemObj.y(1));
-  EXPECT_DOUBLE_EQ(y(2), problemObj.y(2));
+  EXPECT_NEAR(y(0), problemObj.y(0), 1e-15);
+  EXPECT_NEAR(y(1), problemObj.y(1), 1e-15);
+  EXPECT_NEAR(y(2), problemObj.y(2), 1e-15);
 }
 
 TEST(ode, implicit_bdf2_custom_policy)
@@ -59,7 +59,7 @@ TEST(ode, implicit_bdf2_custom_policy)
   problemObj.analyticAdvanceBackEulerNSteps(dt, 1);
   problemObj.analyticAdvanceBDF2NSteps(dt, 3);
   std::cout << std::setprecision(14) << problemObj.y << "\n";
-  EXPECT_DOUBLE_EQ(y(0), problemObj.y(0));
-  EXPECT_DOUBLE_EQ(y(1), problemObj.y(1));
-  EXPECT_DOUBLE_EQ(y(2), problemObj.y(2));
+  EXPECT_NEAR(y(0), problemObj.y(0), 1e-15);
+  EXPECT_NEAR(y(1), problemObj.y(1), 1e-15);
+  EXPECT_NEAR(y(2), problemObj.y(2), 1e-15);
 }

--- a/tests/functional_small/ode_steppers/ode_rk4_custom_ind_var_type_eigen.cc
+++ b/tests/functional_small/ode_steppers/ode_rk4_custom_ind_var_type_eigen.cc
@@ -11,9 +11,9 @@
   MyCustomTime dt{0.1};							\
   ode::advance_n_steps(stepperObj, y, t0, dt, pressio::ode::StepCount(1)); \
   appObj.analyticAdvanceRK4(dt);					\
-  EXPECT_DOUBLE_EQ(y(0), appObj.y(0));					\
-  EXPECT_DOUBLE_EQ(y(1), appObj.y(1));					\
-  EXPECT_DOUBLE_EQ(y(2), appObj.y(2));					\
+  EXPECT_NEAR(y(0), appObj.y(0), 1e-15);	\
+  EXPECT_NEAR(y(1), appObj.y(1), 1e-15);	\
+  EXPECT_NEAR(y(2), appObj.y(2), 1e-15);	\
 
 TEST(ode_explicit_steppers, rk4_system_reference_custom_ind_var_type)
 {

--- a/tests/functional_small/ode_steppers/ode_rk4_simple_correctness_eigen.cc
+++ b/tests/functional_small/ode_steppers/ode_rk4_simple_correctness_eigen.cc
@@ -9,9 +9,9 @@
   double dt = 0.1;				    \
   ode::advance_n_steps(stepperObj, y, 0.0, dt, pressio::ode::StepCount(1));  \
   appObj.analyticAdvanceRK4(dt);		    \
-  EXPECT_DOUBLE_EQ(y(0), appObj.y(0));		    \
-  EXPECT_DOUBLE_EQ(y(1), appObj.y(1));		    \
-  EXPECT_DOUBLE_EQ(y(2), appObj.y(2));		    \
+  EXPECT_NEAR(y(0), appObj.y(0), 1e-15); \
+  EXPECT_NEAR(y(1), appObj.y(1), 1e-15); \
+  EXPECT_NEAR(y(2), appObj.y(2), 1e-15); \
 
 TEST(ode_explicit_steppers, rk4_system_reference)
 {

--- a/tests/functional_small/ops/ops_epetra_vector.cc
+++ b/tests/functional_small/ops/ops_epetra_vector.cc
@@ -90,7 +90,7 @@ TEST_F(epetraVectorGlobSize15Fixture, vector_norm2)
 {
   myVector_->PutScalar(1.0);
   auto mynorm = pressio::ops::norm2(*myVector_);
-  EXPECT_DOUBLE_EQ(mynorm, std::sqrt(15.0));
+  EXPECT_NEAR(mynorm, std::sqrt(15.0), 1e-15);
 }
 
 TEST_F(epetraVectorGlobSize15Fixture, vector_norm1)

--- a/tests/functional_small/ops/ops_tpetra_block_vector.cc
+++ b/tests/functional_small/ops/ops_tpetra_block_vector.cc
@@ -96,7 +96,7 @@ TEST_F(tpetraBlockVectorGlobSize15BlockSize5Fixture, vector_norm2)
 {
   pressio::ops::fill(*myVector_, 1.0);
   auto mynorm = pressio::ops::norm2(*myVector_);
-  EXPECT_DOUBLE_EQ(mynorm, std::sqrt(75.0));
+  EXPECT_NEAR(mynorm, std::sqrt(75.0), 1e-15);
 }
 
 TEST_F(tpetraBlockVectorGlobSize15BlockSize5Fixture, vector_norm1)

--- a/tests/functional_small/ops/ops_tpetra_vector.cc
+++ b/tests/functional_small/ops/ops_tpetra_vector.cc
@@ -96,7 +96,7 @@ TEST_F(tpetraVectorGlobSize15Fixture, vector_norm2)
 {
   pressio::ops::fill(*myVector_, 1.0);
   auto mynorm = pressio::ops::norm2(*myVector_);
-  EXPECT_DOUBLE_EQ(mynorm, std::sqrt(15.0));
+  EXPECT_NEAR(mynorm, std::sqrt(15.0), 1e-15);
 }
 
 TEST_F(tpetraVectorGlobSize15Fixture, vector_norm1)

--- a/tests/functional_small/rom/lspg_steady/main1.cc
+++ b/tests/functional_small/rom/lspg_steady/main1.cc
@@ -86,7 +86,7 @@ struct FakeNonLinSolverSteady
       int count = 0;
       for (int i=0; i<N_; ++i){
         for (int j=0; j<3; ++j){
-          EXPECT_DOUBLE_EQ(J(i,j), start + (double)count++);
+          EXPECT_NEAR(J(i,j), start + (double)count++, 1e-15);
         }
       }
 
@@ -110,7 +110,7 @@ struct FakeNonLinSolverSteady
       count = 0;
       for (int i=0; i<N_; ++i){
         for (int j=0; j<3; ++j){
-          EXPECT_DOUBLE_EQ(J(i,j), start + (double)count++);
+          EXPECT_NEAR(J(i,j), start + (double)count++, 1e-15);
         }
       }
 

--- a/tests/functional_small/rom/lspg_steady/main2.cc
+++ b/tests/functional_small/rom/lspg_steady/main2.cc
@@ -82,7 +82,7 @@ struct FakeNonLinSolver
       int count = 0;
       for (int i=0; i<N_; ++i){
         for (int j=0; j<3; ++j){
-          EXPECT_DOUBLE_EQ(J(i,j), start + (double)count++);
+          EXPECT_NEAR(J(i,j), start + (double)count++, 1e-15);
         }
       }
 
@@ -106,7 +106,7 @@ struct FakeNonLinSolver
       count = 0;
       for (int i=0; i<N_; ++i){
         for (int j=0; j<3; ++j){
-          EXPECT_DOUBLE_EQ(J(i,j), start + (double)count++);
+          EXPECT_NEAR(J(i,j), start + (double)count++, 1e-15);
         }
       }
 

--- a/tests/functional_small/rom/lspg_steady/main3.cc
+++ b/tests/functional_small/rom/lspg_steady/main3.cc
@@ -93,7 +93,7 @@ struct FakeNonLinSolverSteady
       int count = 0;
       for (int i=0; i<N_; ++i){
         for (int j=0; j<3; ++j){
-          EXPECT_DOUBLE_EQ(J(i,j), start + (double)count++);
+          EXPECT_NEAR(J(i,j), start + (double)count++, 1e-15);
         }
       }
 
@@ -117,7 +117,7 @@ struct FakeNonLinSolverSteady
       count = 0;
       for (int i=0; i<N_; ++i){
         for (int j=0; j<3; ++j){
-          EXPECT_DOUBLE_EQ(J(i,j), start + (double)count++);
+          EXPECT_NEAR(J(i,j), start + (double)count++, 1e-15);
         }
       }
 

--- a/tests/functional_small/rom/lspg_steady/main4.cc
+++ b/tests/functional_small/rom/lspg_steady/main4.cc
@@ -95,7 +95,7 @@ struct FakeNonLinSolverSteady
       int count = 0;
       for (int i=0; i<N_; ++i){
         for (int j=0; j<3; ++j){
-          EXPECT_DOUBLE_EQ(J(i,j), start + (double)count++);
+          EXPECT_NEAR(J(i,j), start + (double)count++, 1e-15);
         }
       }
 
@@ -119,7 +119,7 @@ struct FakeNonLinSolverSteady
       count = 0;
       for (int i=0; i<N_; ++i){
         for (int j=0; j<3; ++j){
-          EXPECT_DOUBLE_EQ(J(i,j), start + (double)count++);
+          EXPECT_NEAR(J(i,j), start + (double)count++, 1e-15);
         }
       }
 

--- a/tests/functional_small/rom/lspg_unsteady/main1.cc
+++ b/tests/functional_small/rom/lspg_unsteady/main1.cc
@@ -113,13 +113,13 @@ struct FakeNonLinSolver
 	compute_f(ynp1, f, mytime);
 	// for callcount1, iter1: ynp1 and yn should be same, so use f only
 	for (int i=0; i<N_; ++i){
-	  EXPECT_DOUBLE_EQ(R(i), -dt_*f(i));
+	  EXPECT_NEAR(R(i), -dt_*f(i), 1e-15);
 	}
 	int count = 0;
 	for (int i=0; i<N_; ++i){
 	  for (int j=0; j<3; ++j){
 	    const auto phi_val =  (double)count++;
-	    EXPECT_DOUBLE_EQ(J(i,j), phi_val - dt_*(phi_val+mytime));
+	    EXPECT_NEAR(J(i,j), phi_val - dt_*(phi_val+mytime), 1e-15);
 	  }
 	}
 
@@ -146,13 +146,13 @@ struct FakeNonLinSolver
 	compute_f(ynp1, f, mytime);
 
 	for (int i=0; i<N_; ++i){
-	  EXPECT_DOUBLE_EQ(R(i), ynp1(i)-yn(i)-dt_*f(i));
+	  EXPECT_NEAR(R(i), ynp1(i)-yn(i)-dt_*f(i), 1e-15);
 	}
 	int count = 0;
 	for (int i=0; i<N_; ++i){
 	  for (int j=0; j<3; ++j){
 	    const auto phi_val =  (double)count++;
-	    EXPECT_DOUBLE_EQ(J(i,j), phi_val - dt_*(phi_val+2.));
+	    EXPECT_NEAR(J(i,j), phi_val - dt_*(phi_val+2.), 1e-15);
 	  }
 	}
 
@@ -182,13 +182,13 @@ struct FakeNonLinSolver
 	compute_f(ynp1, f, mytime);
 	// for callcount2, iter1: ynp1 and yn should be same, so use f only
 	for (int i=0; i<N_; ++i){
-	  EXPECT_DOUBLE_EQ(R(i), -dt_*f(i));
+	  EXPECT_NEAR(R(i), -dt_*f(i), 1e-15);
 	}
 	int count = 0;
 	for (int i=0; i<N_; ++i){
 	  for (int j=0; j<3; ++j){
 	    const auto phi_val =  (double)count++;
-	    EXPECT_DOUBLE_EQ(J(i,j), phi_val - dt_*(phi_val+mytime));
+	    EXPECT_NEAR(J(i,j), phi_val - dt_*(phi_val+mytime), 1e-15);
 	  }
 	}
 
@@ -215,13 +215,13 @@ struct FakeNonLinSolver
 	compute_f(ynp1, f, mytime);
 
 	for (int i=0; i<N_; ++i){
-	  EXPECT_DOUBLE_EQ(R(i), ynp1(i)-yn(i)-dt_*f(i));
+	  EXPECT_NEAR(R(i), ynp1(i)-yn(i)-dt_*f(i), 1e-15);
 	}
 	int count = 0;
 	for (int i=0; i<N_; ++i){
 	  for (int j=0; j<3; ++j){
 	    const auto phi_val =  (double)count++;
-	    EXPECT_DOUBLE_EQ(J(i,j), phi_val - dt_*(phi_val+mytime));
+	    EXPECT_NEAR(J(i,j), phi_val - dt_*(phi_val+mytime), 1e-15);
 	  }
 	}
 

--- a/tests/functional_small/rom/lspg_unsteady/main4.cc
+++ b/tests/functional_small/rom/lspg_unsteady/main4.cc
@@ -67,13 +67,13 @@ struct FakeNonLinSolver
 	compute_f(ynp1, f, mytime);
 	// for callcount1, iter1: ynp1 and yn should be same, so use f only
 	for (int i=0; i<N_; ++i){
-	  EXPECT_DOUBLE_EQ(R(i), -dt_*f(i));
+	  EXPECT_NEAR(R(i), -dt_*f(i), 1e-15);
 	}
 	int count = 0;
 	for (int i=0; i<N_; ++i){
 	  for (int j=0; j<3; ++j){
 	    const auto phi_val =  (double)count++;
-	    EXPECT_DOUBLE_EQ(J(i,j), phi_val - dt_*(phi_val+mytime));
+	    EXPECT_NEAR(J(i,j), phi_val - dt_*(phi_val+mytime), 1e-15);
 	  }
 	}
 
@@ -100,13 +100,13 @@ struct FakeNonLinSolver
 	compute_f(ynp1, f, mytime);
 
 	for (int i=0; i<N_; ++i){
-	  EXPECT_DOUBLE_EQ(R(i), ynp1(i)-yn(i)-dt_*f(i));
+	  EXPECT_NEAR(R(i), ynp1(i)-yn(i)-dt_*f(i), 1e-15);
 	}
 	int count = 0;
 	for (int i=0; i<N_; ++i){
 	  for (int j=0; j<3; ++j){
 	    const auto phi_val =  (double)count++;
-	    EXPECT_DOUBLE_EQ(J(i,j), phi_val - dt_*(phi_val+2.));
+	    EXPECT_NEAR(J(i,j), phi_val - dt_*(phi_val+2.), 1e-15);
 	  }
 	}
 
@@ -136,13 +136,13 @@ struct FakeNonLinSolver
 	compute_f(ynp1, f, mytime);
 	// for callcount2, iter1: ynp1 and yn should be same, so use f only
 	for (int i=0; i<N_; ++i){
-	  EXPECT_DOUBLE_EQ(R(i), -dt_*f(i));
+	  EXPECT_NEAR(R(i), -dt_*f(i), 1e-15);
 	}
 	int count = 0;
 	for (int i=0; i<N_; ++i){
 	  for (int j=0; j<3; ++j){
 	    const auto phi_val =  (double)count++;
-	    EXPECT_DOUBLE_EQ(J(i,j), phi_val - dt_*(phi_val+mytime));
+	    EXPECT_NEAR(J(i,j), phi_val - dt_*(phi_val+mytime), 1e-15);
 	  }
 	}
 
@@ -169,13 +169,13 @@ struct FakeNonLinSolver
 	compute_f(ynp1, f, mytime);
 
 	for (int i=0; i<N_; ++i){
-	  EXPECT_DOUBLE_EQ(R(i), ynp1(i)-yn(i)-dt_*f(i));
+	  EXPECT_NEAR(R(i), ynp1(i)-yn(i)-dt_*f(i), 1e-15);
 	}
 	int count = 0;
 	for (int i=0; i<N_; ++i){
 	  for (int j=0; j<3; ++j){
 	    const auto phi_val =  (double)count++;
-	    EXPECT_DOUBLE_EQ(J(i,j), phi_val - dt_*(phi_val+mytime));
+	    EXPECT_NEAR(J(i,j), phi_val - dt_*(phi_val+mytime), 1e-15);
 	  }
 	}
 

--- a/tests/functional_small/solvers_nonlinear/operators.cc
+++ b/tests/functional_small/solvers_nonlinear/operators.cc
@@ -28,7 +28,7 @@ TEST(solvers_nonlinear, operators_residual_jacobian)
 
   typename op_t::residual_norm_type norm1 = {};
   operators.residualNorm(sysObj, state, norm1);
-  EXPECT_DOUBLE_EQ(norm1, std::sqrt(5.));
+  EXPECT_NEAR(norm1, std::sqrt(5.), 1e-15);
 }
 
 TEST(solvers_nonlinear, operators_residual_jacobian_fused)
@@ -57,7 +57,7 @@ TEST(solvers_nonlinear, operators_residual_jacobian_fused)
 
   typename op_t::residual_norm_type norm1 = {};
   operators.residualNorm(sysObj, state, norm1);
-  EXPECT_DOUBLE_EQ(norm1, std::sqrt(5.));
+  EXPECT_NEAR(norm1, std::sqrt(5.), 1e-15);
 }
 
 TEST(solvers_nonlinear, operators_hessian_gradient_hg_api_enable_jacobian_computation)
@@ -246,7 +246,7 @@ TEST(solvers_nonlinear, operators_hessian_gradient_rj_api_enable_jacobian_comput
   using residual_norm_type = typename op_t::residual_norm_type;
   residual_norm_type norm = {};
   operators.computeOperators(sysObj, state, norm, true);
-  EXPECT_DOUBLE_EQ(norm, std::sqrt(5));
+  EXPECT_NEAR(norm, std::sqrt(5), 1e-15);
 
   // check gradient
   const auto & g = operators.gradientCRef();
@@ -265,7 +265,7 @@ TEST(solvers_nonlinear, operators_hessian_gradient_rj_api_enable_jacobian_comput
   // check norm
   residual_norm_type rNorm = {};
   operators.residualNorm(sysObj, state, rNorm);
-  EXPECT_DOUBLE_EQ(rNorm, std::sqrt(5.));
+  EXPECT_NEAR(rNorm, std::sqrt(5.), 1e-15);
 }
 
 TEST(solvers_nonlinear, operators_hessian_gradient_rj_api_disable_jacobian_computation)
@@ -294,7 +294,7 @@ TEST(solvers_nonlinear, operators_hessian_gradient_rj_api_disable_jacobian_compu
   using residual_norm_type = typename op_t::residual_norm_type;
   residual_norm_type norm = {};
   operators.computeOperators(sysObj, state, norm, false);
-  EXPECT_DOUBLE_EQ(norm, std::sqrt(5));
+  EXPECT_NEAR(norm, std::sqrt(5), 1e-15);
 
   // check hessian
   const auto & H = operators.hessianCRef();
@@ -316,7 +316,7 @@ TEST(solvers_nonlinear, operators_hessian_gradient_rj_api_disable_jacobian_compu
   // check norm
   residual_norm_type rNorm = {};
   operators.residualNorm(sysObj, state, rNorm);
-  EXPECT_DOUBLE_EQ(rNorm, std::sqrt(5.));
+  EXPECT_NEAR(rNorm, std::sqrt(5.), 1e-15);
 }
 
 TEST(solvers_nonlinear, operators_hessian_gradient_weighted_rj_api_enable_jacobian_computation)
@@ -349,7 +349,7 @@ TEST(solvers_nonlinear, operators_hessian_gradient_weighted_rj_api_enable_jacobi
   using residual_norm_type = typename op_t::residual_norm_type;
   residual_norm_type norm = {};
   operators.computeOperators(sysObj, state, norm, true);
-  EXPECT_DOUBLE_EQ(norm, std::sqrt(15.));
+  EXPECT_NEAR(norm, std::sqrt(15.), 1e-15);
 
   // check gradient
   const auto & g = operators.gradientCRef();
@@ -426,6 +426,6 @@ TEST(solvers_nonlinear, operators_hessian_gradient_weighted_rj_api_disable_jacob
   // check norm
   residual_norm_type rNorm = {};
   operators.residualNorm(sysObj, state, rNorm);
-  EXPECT_DOUBLE_EQ(rNorm, std::sqrt(15.));
+  EXPECT_NEAR(rNorm, std::sqrt(15.), 1e-15);
 }
 


### PR DESCRIPTION
This PR replaces exact `EXPECT_DOUBLE_EQ` comparisons with tolerance-based `EXPECT_NEAR`.

Fixes #437

> **Note:** Baseline tolerance picked at `1e-15: to be adjusted where hinted by failing tests.