### PR TITLE
docs: rom: update `LinearSubspace` constraints

### DIFF
--- a/docs/source/components/rom_linear_subspace.rst
+++ b/docs/source/components/rom_linear_subspace.rst
@@ -54,10 +54,6 @@ Let ``basis_matrix_type`` be equal to ``std::remove_cv_t<BasisMatrixType>``, the
 
 - and :cpp:`std::is_copy_constructible<basis_matrix_type>::value == true`
 
-- and :cpp:`std::is_pointer<basis_matrix_type>::value == false`
-
-- and :cpp:`pressio::mpl::is_std_shared_ptr<basis_matrix_type>::value == false`
-
 - and :cpp:`pressio::Traits::<basis_matrix_type>::rank == 2`
 
 


### PR DESCRIPTION
This PR updates `LinearSubspace` constraints according to https://github.com/Pressio/pressio/issues/440#issuecomment-1293062547.

Fixes #440