### PR TITLE
expressions: fix templating typo

### DIFF
--- a/include/pressio/expressions/impl/diag_classes.hpp
+++ b/include/pressio/expressions/impl/diag_classes.hpp
@@ -182,7 +182,7 @@ public:
 
   template<typename _MatrixType = MatrixType>
   mpl::enable_if_t<
-    std::is_same<typename MatrixType::memory_space, Kokkos::HostSpace>::value,
+    std::is_same<typename _MatrixType::memory_space, Kokkos::HostSpace>::value,
     ref_t
     >
   operator()(size_t i) const

--- a/include/pressio/expressions/impl/span_classes.hpp
+++ b/include/pressio/expressions/impl/span_classes.hpp
@@ -205,7 +205,7 @@ public:
 
   template<typename _VectorType = VectorType>
   mpl::enable_if_t<
-    std::is_same<typename VectorType::memory_space, Kokkos::HostSpace>::value,
+    std::is_same<typename _VectorType::memory_space, Kokkos::HostSpace>::value,
     ref_t
     >
   operator()(size_t i) const

--- a/include/pressio/expressions/impl/subspan_classes.hpp
+++ b/include/pressio/expressions/impl/subspan_classes.hpp
@@ -229,7 +229,7 @@ public:
    */
   template<typename _MatrixType = MatrixType>
   mpl::enable_if_t<
-    std::is_same<typename MatrixType::memory_space, Kokkos::HostSpace>::value,
+    std::is_same<typename _MatrixType::memory_space, Kokkos::HostSpace>::value,
     ref_t
     >
   operator()(const size_t & i, const size_t & j) const


### PR DESCRIPTION
Fixing a typo we found with @fnrizzi based on `nvcc` 11.8 error:
```
/pressio/include/pressio/././mpl/enable_if_t.hpp(60): error: class "std::enable_if<false, double &>" has no member "type"
          detected during:
            instantiation of type "pressio::mpl::enable_if_t<false, double &>" 
/pressio/include/pressio/././expressions/impl/span_classes.hpp(210): here
            instantiation of class "pressio::expressions::impl::SpanExpr<VectorType, pressio::mpl::enable_if_t<pressio::is_vector_kokkos<VectorType, void>::value, void>> [with VectorType=Kokkos::View<double *>]" 
/pressio/include/pressio/././expressions/span.hpp(77): here
            instantiation of "auto pressio::span(T &, std::size_t, std::size_t) [with T=Kokkos::View<double *>]" 
/pressio/tests/functional_small/ops/ops_kokkos_level2.cc(82): here

/pressio/include/pressio/././expressions/impl/span_classes.hpp(177): warning #186-D: pointless comparison of unsigned integer with zero
          detected during instantiation of "pressio::expressions::impl::SpanExpr<VectorType, pressio::mpl::enable_if_t<pressio::is_vector_kokkos<VectorType, void>::value, void>>::SpanExpr(VectorType &, pressio::expressions::impl::SpanExpr<VectorType, pressio::mpl::enable_if_t<pressio::is_vector_kokkos<VectorType, void>::value, void>>::pair_t) [with VectorType=Kokkos::View<double *>]" 
/pressio/include/pressio/././expressions/span.hpp(77): here

1 error detected in the compilation of "/pressio/tests/functional_small/ops/ops_kokkos_level2.cc".
```