### PR TITLE
test: fix random CI failures

### DIFF
--- a/tests/functional_small/solvers_nonlinear/standard_gauss_newton_normal_equations/gn_normal_eq_print_metrics_eigen.cc
+++ b/tests/functional_small/solvers_nonlinear/standard_gauss_newton_normal_equations/gn_normal_eq_print_metrics_eigen.cc
@@ -57,7 +57,10 @@ int main()
   // to file works as expected by omitting lables/cols names
 
   std::string sentinel = "PASSED";
-  pressio::log::initialize(pressio::logto::fileAndTerminal, "log.txt");
+  // Important: use unique log name, because we read the log contents here
+  // and don't want any other test to write into the same log file.
+  const auto log_file_name = "log_gn_normal_eq_print_metrics_eigen.txt";
+  pressio::log::initialize(pressio::logto::fileAndTerminal, log_file_name);
   pressio::log::setVerbosity({pressio::log::level::info, pressio::log::level::debug});
 
   using namespace pressio;
@@ -81,7 +84,7 @@ int main()
   pressio::log::finalize();
 
   // check file printed
-  std::ifstream file("log.txt");
+  std::ifstream file(log_file_name);
   if (file.is_open())
   {
     std::string line;


### PR DESCRIPTION
This PR makes the tests that read and verify their log contents use unique log file names fixes. Otherwise multiple tests write to the same "log.txt" file and its unintended content causes the reading test crash like in [this run](https://github.com/Pressio/pressio/actions/runs/3602729067/jobs/6070053889):
![shared_log_crash](https://user-images.githubusercontent.com/29018159/205359060-903d4199-8349-4973-a19a-a8473e3b7bd3.png)
