### PR TITLE
ops: teuchos: implement missing level1 ops

### DIFF
--- a/include/pressio/ops.hpp
+++ b/include/pressio/ops.hpp
@@ -114,6 +114,7 @@ template<class ...> struct matching_extents;
 #ifdef PRESSIO_ENABLE_TPL_TRILINOS
 // Teuchos
 #include "ops/teuchos/ops_extent.hpp"
+#include "ops/teuchos/ops_set_zero.hpp"
 #include "ops/teuchos/ops_scale.hpp"
 #include "ops/teuchos/ops_fill.hpp"
 #include "ops/teuchos/ops_level2.hpp"

--- a/include/pressio/ops.hpp
+++ b/include/pressio/ops.hpp
@@ -114,6 +114,7 @@ template<class ...> struct matching_extents;
 #ifdef PRESSIO_ENABLE_TPL_TRILINOS
 // Teuchos
 #include "ops/teuchos/ops_extent.hpp"
+#include "ops/teuchos/ops_fill.hpp"
 #include "ops/teuchos/ops_level2.hpp"
 
 // Tpetra

--- a/include/pressio/ops.hpp
+++ b/include/pressio/ops.hpp
@@ -114,6 +114,7 @@ template<class ...> struct matching_extents;
 #ifdef PRESSIO_ENABLE_TPL_TRILINOS
 // Teuchos
 #include "ops/teuchos/ops_extent.hpp"
+#include "ops/teuchos/ops_scale.hpp"
 #include "ops/teuchos/ops_fill.hpp"
 #include "ops/teuchos/ops_level2.hpp"
 

--- a/include/pressio/ops.hpp
+++ b/include/pressio/ops.hpp
@@ -112,6 +112,10 @@ template<class ...> struct matching_extents;
 #endif
 
 #ifdef PRESSIO_ENABLE_TPL_TRILINOS
+// Teuchos
+#include "ops/teuchos/ops_extent.hpp"
+#include "ops/teuchos/ops_level2.hpp"
+
 // Tpetra
 #include "ops/tpetra/ops_clone.hpp"
 #include "ops/tpetra/ops_extent.hpp"
@@ -159,9 +163,6 @@ template<class ...> struct matching_extents;
 #include "ops/epetra/ops_multi_vector_update.hpp"
 #include "ops/epetra/ops_level2.hpp"
 #include "ops/epetra/ops_level3.hpp"
-
-// teuchos
-#include "ops/teuchos/ops_level2.hpp"
 #endif //PRESSIO_ENABLE_TPL_TRILINOS
 
 // keep this last

--- a/include/pressio/ops/teuchos/ops_extent.hpp
+++ b/include/pressio/ops/teuchos/ops_extent.hpp
@@ -58,12 +58,7 @@ mpl::enable_if_t<
   >
 extent(const T & objectIn, IndexType i)
 {
-  if (i == 0)
-    return objectIn.numRows();
-  else if (i == 1)
-    return objectIn.numCols();
-  else
-    return 0;
+  return (i == 0) ? objectIn.length() : 1;
 }
 
 }}

--- a/include/pressio/ops/teuchos/ops_extent.hpp
+++ b/include/pressio/ops/teuchos/ops_extent.hpp
@@ -56,7 +56,7 @@ mpl::enable_if_t<
   ::pressio::is_dense_vector_teuchos<T>::value,
   typename T::ordinalType
   >
-extent(const T & objectIn, const IndexType i)
+extent(const T & objectIn, IndexType i)
 {
   if (i == 0)
     return objectIn.numRows();

--- a/include/pressio/ops/teuchos/ops_extent.hpp
+++ b/include/pressio/ops/teuchos/ops_extent.hpp
@@ -1,0 +1,70 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+// ops_extent.hpp
+//                     		  Pressio
+//                             Copyright 2019
+//    National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+//
+// Under the terms of Contract DE-NA0003525 with NTESS, the
+// U.S. Government retains certain rights in this software.
+//
+// Pressio is licensed under BSD-3-Clause terms of use:
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Francesco Rizzi (fnrizzi@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef OPS_TEUCHOS_OPS_EXTENT_HPP_
+#define OPS_TEUCHOS_OPS_EXTENT_HPP_
+
+namespace pressio{ namespace ops{
+
+template<class T, class IndexType>
+mpl::enable_if_t<
+  ::pressio::is_dense_vector_teuchos<T>::value,
+  typename T::ordinalType
+  >
+extent(const T & objectIn, const IndexType i)
+{
+  if (i == 0)
+    return objectIn.numRows();
+  else if (i == 1)
+    return objectIn.numCols();
+  else
+    return 0;
+}
+
+}}
+#endif  // OPS_TEUCHOS_OPS_EXTENT_HPP_

--- a/include/pressio/ops/teuchos/ops_fill.hpp
+++ b/include/pressio/ops/teuchos/ops_fill.hpp
@@ -1,0 +1,66 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+// ops_fill.hpp
+//                     		  Pressio
+//                             Copyright 2019
+//    National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+//
+// Under the terms of Contract DE-NA0003525 with NTESS, the
+// U.S. Government retains certain rights in this software.
+//
+// Pressio is licensed under BSD-3-Clause terms of use:
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Francesco Rizzi (fnrizzi@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef OPS_TEUCHOS_OPS_FILL_HPP_
+#define OPS_TEUCHOS_OPS_FILL_HPP_
+
+namespace pressio{ namespace ops{
+
+template<class T, class ScalarType>
+::pressio::mpl::enable_if_t<
+  ::pressio::is_dense_vector_teuchos<T>::value
+  && std::is_convertible<ScalarType, typename ::pressio::Traits<T>::scalar_type>::value
+  >
+fill(T & objectIn, const ScalarType value)
+{
+  const typename ::pressio::Traits<T>::scalar_type v(value);
+  objectIn = v;
+}
+
+}} // namespace pressio::ops
+#endif  // OPS_TEUCHOS_OPS_FILL_HPP_

--- a/include/pressio/ops/teuchos/ops_fill.hpp
+++ b/include/pressio/ops/teuchos/ops_fill.hpp
@@ -56,7 +56,7 @@ template<class T, class ScalarType>
   ::pressio::is_dense_vector_teuchos<T>::value
   && std::is_convertible<ScalarType, typename ::pressio::Traits<T>::scalar_type>::value
   >
-fill(T & objectIn, const ScalarType value)
+fill(T & objectIn, ScalarType value)
 {
   const typename ::pressio::Traits<T>::scalar_type v(value);
   objectIn = v;

--- a/include/pressio/ops/teuchos/ops_scale.hpp
+++ b/include/pressio/ops/teuchos/ops_scale.hpp
@@ -56,7 +56,7 @@ template<class T, class ScalarType>
   ::pressio::is_dense_vector_teuchos<T>::value
   && std::is_convertible<ScalarType, typename ::pressio::Traits<T>::scalar_type>::value
   >
-scale(T & objectIn, const ScalarType value)
+scale(T & objectIn, ScalarType value)
 {
   const typename ::pressio::Traits<T>::scalar_type v(value);
   objectIn *= v;

--- a/include/pressio/ops/teuchos/ops_scale.hpp
+++ b/include/pressio/ops/teuchos/ops_scale.hpp
@@ -1,0 +1,66 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+// ops_scale.hpp
+//                     		  Pressio
+//                             Copyright 2019
+//    National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+//
+// Under the terms of Contract DE-NA0003525 with NTESS, the
+// U.S. Government retains certain rights in this software.
+//
+// Pressio is licensed under BSD-3-Clause terms of use:
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Francesco Rizzi (fnrizzi@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef OPS_TEUCHOS_OPS_SCALE_HPP_
+#define OPS_TEUCHOS_OPS_SCALE_HPP_
+
+namespace pressio{ namespace ops{
+
+template<class T, class ScalarType>
+::pressio::mpl::enable_if_t<
+  ::pressio::is_dense_vector_teuchos<T>::value
+  && std::is_convertible<ScalarType, typename ::pressio::Traits<T>::scalar_type>::value
+  >
+scale(T & objectIn, const ScalarType value)
+{
+  const typename ::pressio::Traits<T>::scalar_type v(value);
+  objectIn *= v;
+}
+
+}} // namespace pressio::ops
+#endif  // OPS_TEUCHOS_OPS_SCALE_HPP_

--- a/include/pressio/ops/teuchos/ops_set_zero.hpp
+++ b/include/pressio/ops/teuchos/ops_set_zero.hpp
@@ -1,0 +1,65 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+// ops_set_zero.hpp
+//                     		  Pressio
+//                             Copyright 2019
+//    National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+//
+// Under the terms of Contract DE-NA0003525 with NTESS, the
+// U.S. Government retains certain rights in this software.
+//
+// Pressio is licensed under BSD-3-Clause terms of use:
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Francesco Rizzi (fnrizzi@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef OPS_TEUCHOS_OPS_SET_ZERO_HPP_
+#define OPS_TEUCHOS_OPS_SET_ZERO_HPP_
+
+namespace pressio{ namespace ops{
+
+template <typename T>
+::pressio::mpl::enable_if_t<
+  ::pressio::is_dense_vector_teuchos<T>::value
+  >
+set_zero(T & objectIn)
+{
+  using sc_t = typename ::pressio::Traits<T>::scalar_type;
+  objectIn = ::pressio::utils::Constants<sc_t>::zero();
+}
+
+}} // namespace pressio::ops
+#endif  // OPS_TEUCHOS_OPS_SET_ZERO_HPP_


### PR DESCRIPTION
@fnrizzi 

This PR implements missing level1 ops for `Teuchos::SerialDenseVector<Index, Scalar>`:
* `extent()`
* `fill()`
* `set_zero()`
* `scale()`
