### PR TITLE
ops: kokkos: revise matrix-matrix product

### DIFF
--- a/include/pressio/ops/kokkos/ops_level3.hpp
+++ b/include/pressio/ops/kokkos/ops_level3.hpp
@@ -85,6 +85,11 @@ product(::pressio::nontranspose /*unused*/,
   const beta_type beta,
   C_type & C)
 {
+
+  assert( ::pressio::ops::extent(C, 0) == ::pressio::ops::extent(A, 0) );
+  assert( ::pressio::ops::extent(C, 1) == ::pressio::ops::extent(B, 1) );
+  assert( ::pressio::ops::extent(A, 1) == ::pressio::ops::extent(B, 0) );
+
   const char ctA = 'N';
   const char ctB = 'N';
   using sc_t = typename ::pressio::Traits<A_type>::scalar_type;
@@ -121,6 +126,11 @@ product(::pressio::transpose /*unused*/,
 	const beta_type beta,
 	C_type & C)
 {
+
+  assert( ::pressio::ops::extent(C, 0) == ::pressio::ops::extent(A, 1) );
+  assert( ::pressio::ops::extent(C, 1) == ::pressio::ops::extent(B, 1) );
+  assert( ::pressio::ops::extent(A, 0) == ::pressio::ops::extent(B, 0) );
+
   const char ctA = 'T';
   const char ctB = 'N';
   using sc_t = typename ::pressio::Traits<A_type>::scalar_type;
@@ -160,7 +170,7 @@ product(::pressio::transpose modeA,
 /*---------------------------------------------------
 * special case A==B and op(A)=A^T, op(B)=B, return C
 -----------------------------------------------------*/
-template <typename A_type, typename alpha_type, typename C_type>
+template <typename C_type, typename A_type, typename alpha_type>
 ::pressio::mpl::enable_if_t<
   // level3 common constraints
      ::pressio::Traits<A_type>::rank == 2

--- a/include/pressio/ops/kokkos/ops_level3.hpp
+++ b/include/pressio/ops/kokkos/ops_level3.hpp
@@ -60,60 +60,98 @@ namespace pressio{ namespace ops{
 //-------------------------------------------
 // specialize for op(A) = A and op(B) = B
 //-------------------------------------------
-template <typename A_type, typename B_type, typename scalar_type, typename C_type>
+template <typename A_type, typename B_type, typename alpha_type, typename beta_type, typename C_type>
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_dense_matrix_kokkos<A_type>::value and
-  ::pressio::is_dense_matrix_kokkos<B_type>::value and
-  ::pressio::is_dense_matrix_kokkos<C_type>::value
+  // level3 common constraints
+     ::pressio::Traits<A_type>::rank == 2
+  && ::pressio::Traits<B_type>::rank == 2
+  && ::pressio::Traits<C_type>::rank == 2
+  // TPL/container specific
+  && ::pressio::is_dense_matrix_kokkos<A_type>::value
+  && ::pressio::is_dense_matrix_kokkos<B_type>::value
+  && ::pressio::is_dense_matrix_kokkos<C_type>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<A_type, B_type, C_type>::value
+  && (std::is_floating_point<typename ::pressio::Traits<A_type>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<A_type>::scalar_type>::value)
+  && std::is_convertible<alpha_type, typename ::pressio::Traits<A_type>::scalar_type>::value
+  && std::is_convertible<beta_type,  typename ::pressio::Traits<A_type>::scalar_type>::value
   >
 product(::pressio::nontranspose /*unused*/,
   ::pressio::nontranspose /*unused*/,
-  const scalar_type alpha,
+  const alpha_type alpha,
   const A_type & A,
   const B_type & B,
-  const scalar_type beta,
+  const beta_type beta,
   C_type & C)
 {
   const char ctA = 'N';
   const char ctB = 'N';
-  ::KokkosBlas::gemm(&ctA, &ctB, alpha, A, B, beta, C);
+  using sc_t = typename ::pressio::Traits<A_type>::scalar_type;
+  const sc_t alpha_(alpha);
+  const sc_t beta_(beta);
+  ::KokkosBlas::gemm(&ctA, &ctB, alpha_, A, B, beta_, C);
 }
 
 //-------------------------------------------
 // specialize for op(A) = A^T and op(B) = B
 //-------------------------------------------
-template <typename A_type, typename B_type, typename scalar_type, typename C_type>
+template <typename A_type, typename B_type, typename alpha_type, typename beta_type, typename C_type>
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_dense_matrix_kokkos<A_type>::value and
-  ::pressio::is_dense_matrix_kokkos<B_type>::value and
-  ::pressio::is_dense_matrix_kokkos<C_type>::value
+  // level3 common constraints
+     ::pressio::Traits<A_type>::rank == 2
+  && ::pressio::Traits<B_type>::rank == 2
+  && ::pressio::Traits<C_type>::rank == 2
+  // TPL/container specific
+  && ::pressio::is_dense_matrix_kokkos<A_type>::value
+  && ::pressio::is_dense_matrix_kokkos<B_type>::value
+  && ::pressio::is_dense_matrix_kokkos<C_type>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<A_type, B_type, C_type>::value
+  && (std::is_floating_point<typename ::pressio::Traits<A_type>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<A_type>::scalar_type>::value)
+  && std::is_convertible<alpha_type, typename ::pressio::Traits<A_type>::scalar_type>::value
+  && std::is_convertible<beta_type,  typename ::pressio::Traits<A_type>::scalar_type>::value
   >
 product(::pressio::transpose /*unused*/,
 	::pressio::nontranspose /*unused*/,
-	const scalar_type alpha,
+	const alpha_type alpha,
 	const A_type & A,
 	const B_type & B,
-	const scalar_type beta,
+	const beta_type beta,
 	C_type & C)
 {
   const char ctA = 'T';
   const char ctB = 'N';
-  ::KokkosBlas::gemm(&ctA, &ctB, alpha, A, B, beta, C);
+  using sc_t = typename ::pressio::Traits<A_type>::scalar_type;
+  const sc_t alpha_(alpha);
+  const sc_t beta_(beta);
+  ::KokkosBlas::gemm(&ctA, &ctB, alpha_, A, B, beta_, C);
 }
 
 /*----------------------------------------
 * special case A==B and op(A)=A^T, op(B)=B
 ------------------------------------------*/
-template <typename A_type, typename scalar_type, typename C_type>
+template <typename A_type, typename alpha_type, typename beta_type, typename C_type>
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_dense_matrix_kokkos<A_type>::value and
-  ::pressio::is_dense_matrix_kokkos<C_type>::value
+  // level3 common constraints
+     ::pressio::Traits<A_type>::rank == 2
+  && ::pressio::Traits<C_type>::rank == 2
+  // TPL/container specific
+  && ::pressio::is_dense_matrix_kokkos<A_type>::value
+  && ::pressio::is_dense_matrix_kokkos<C_type>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<A_type, C_type>::value
+  && (std::is_floating_point<typename ::pressio::Traits<A_type>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<A_type>::scalar_type>::value)
+  && std::is_convertible<alpha_type, typename ::pressio::Traits<A_type>::scalar_type>::value
+  && std::is_convertible<beta_type,  typename ::pressio::Traits<A_type>::scalar_type>::value
   >
 product(::pressio::transpose modeA,
 	::pressio::nontranspose modeB,
-	const scalar_type alpha,
+	const alpha_type alpha,
 	const A_type & A,
-	const scalar_type beta,
+	const beta_type beta,
 	C_type & C)
 {
   product(modeA, modeB, alpha, A, A, beta, C);
@@ -122,18 +160,28 @@ product(::pressio::transpose modeA,
 /*---------------------------------------------------
 * special case A==B and op(A)=A^T, op(B)=B, return C
 -----------------------------------------------------*/
-template <typename C_type, typename A_type, typename scalar_type>
+template <typename A_type, typename alpha_type, typename C_type>
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_dense_matrix_kokkos<A_type>::value and
-  ::pressio::is_dense_matrix_kokkos<C_type>::value,
+  // level3 common constraints
+     ::pressio::Traits<A_type>::rank == 2
+  && ::pressio::Traits<C_type>::rank == 2
+  // TPL/container specific
+  && ::pressio::is_dense_matrix_kokkos<A_type>::value
+  && ::pressio::is_dense_matrix_kokkos<C_type>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<A_type, C_type>::value
+  && (std::is_floating_point<typename ::pressio::Traits<A_type>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<A_type>::scalar_type>::value)
+  && std::is_convertible<alpha_type, typename ::pressio::Traits<A_type>::scalar_type>::value,
   C_type
   >
 product(::pressio::transpose modeA,
 	::pressio::nontranspose modeB,
-	const scalar_type alpha,
+	const alpha_type alpha,
 	const A_type & A)
 {
-  constexpr auto zero = ::pressio::utils::Constants<scalar_type>::zero();
+  using sc_t = typename ::pressio::Traits<A_type>::scalar_type;
+  constexpr sc_t zero{0};
   C_type C("opsLev3C", A.extent(1), A.extent(1));
   product(modeA, modeB, alpha, A, A, zero, C);
   return C;

--- a/tests/functional_small/ops/ops_kokkos_level3.cc
+++ b/tests/functional_small/ops/ops_kokkos_level3.cc
@@ -110,6 +110,17 @@ using mat_t = Kokkos::View<double**>;
   EXPECT_DOUBLE_EQ(myR_h(2,0), 12.0); \
   EXPECT_DOUBLE_EQ(myR_h(2,1), 7.0); \
   EXPECT_DOUBLE_EQ(myR_h(2,2), 18.0); \
+  auto myR1 = pressio::ops::product<mat_t>(pressio::transpose(), pressio::nontranspose(), alpha, M); \
+  auto myR1_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), myR1); \
+  EXPECT_DOUBLE_EQ(myR1_h(0,0), 9.0); \
+  EXPECT_DOUBLE_EQ(myR1_h(0,1), 6.0); \
+  EXPECT_DOUBLE_EQ(myR1_h(0,2), 12.0); \
+  EXPECT_DOUBLE_EQ(myR1_h(1,0), 6.0); \
+  EXPECT_DOUBLE_EQ(myR1_h(1,1), 5.0); \
+  EXPECT_DOUBLE_EQ(myR1_h(1,2), 7.0); \
+  EXPECT_DOUBLE_EQ(myR1_h(2,0), 12.0); \
+  EXPECT_DOUBLE_EQ(myR1_h(2,1), 7.0); \
+  EXPECT_DOUBLE_EQ(myR1_h(2,2), 18.0); \
 
 namespace {
 template<class T>


### PR DESCRIPTION
@fnrizzi 

refs #451

* Done:
  - [x] review overload constraints
  - [x] add explicit alpha/beta casts
  - [x] add unit tests for existing overloads
  - [x] list overloads and test cases
* Todo - for discussion:
  - [ ] refactor unit test for expression support
  - [ ] add other expression overloads and cover with tests
  - [ ] add tests for `alpha=0` and `NaN` inside A/B

### Overloads

For `C = alpha * op(A) * op(B) + beta * C` there are following level-3 `pressio::ops::product()` implementations working on Kokkos objects:

| `A` | `B` | `C` | op(A) | op(B) |
|:---:|:---:|:---:|:---:|:---:|
| kokkos matrix | kokkos matrix | kokkos matrix | `nontranspose` | `nontranspose` |
| kokkos matrix | kokkos matrix | kokkos matrix | `transpose` | `nontranspose` |
| kokkos matrix | ⨯<br> (self&nbsp;product) | kokkos matrix | `transpose` | `nontranspose` |
| kokkos matrix | ⨯<br> (self&nbsp;product) | auto<br>(returned value) | `transpose` | `nontranspose` |

### Test coverage

Test cases for Kokkos level-3 implementations of `pressio::ops::product()` (op(B) is always `nontranspose`):

| test | `A` | `B` | `C` | op(A) |
|:---|:---|:---|:---|:---:|
| `ops_kokkos.dense_matrix_dense_matrix_prod` | kokkos view (rank-2) | kokkos view (rank-2) | kokkos view (rank-2) | `nontranspose` |
| `ops_kokkos.dense_matrix_T_dense_matrix_prod` | kokkos view (rank-2) | kokkos view (rank-2) | kokkos view (rank-2) | `transpose` |
| `ops_kokkos.dense_matrix_T_self_prod` | kokkos view (rank-2) | - | kokkos view (rank-2) | `transpose` |
