### PR TITLE
ops: tpetra: revise matrix-matrix product

### DIFF
--- a/include/pressio/ops/tpetra/ops_level3.hpp
+++ b/include/pressio/ops/tpetra/ops_level3.hpp
@@ -64,10 +64,20 @@ template <
   class alpha_t, class beta_t
   >
 ::pressio::mpl::enable_if_t<
-     ::pressio::all_have_traits_and_same_scalar<A_type, B_type, C_type>::value
+  // level3 common constraints
+     ::pressio::Traits<A_type>::rank == 2
+  && ::pressio::Traits<B_type>::rank == 2
+  && ::pressio::Traits<C_type>::rank == 2
+  // TPL/container specific
   && ::pressio::is_multi_vector_tpetra<A_type>::value
   && ::pressio::is_multi_vector_tpetra<B_type>::value
   && ::pressio::is_dense_col_major_matrix_eigen<C_type>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<A_type, B_type, C_type>::value
+  && (std::is_floating_point<typename ::pressio::Traits<A_type>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<A_type>::scalar_type>::value)
+  && std::is_convertible<alpha_t, typename ::pressio::Traits<A_type>::scalar_type>::value
+  && std::is_convertible<beta_t,  typename ::pressio::Traits<A_type>::scalar_type>::value
   >
 product(::pressio::transpose /*unused*/,
 	::pressio::nontranspose /*unused*/,
@@ -132,10 +142,19 @@ template <
   class alpha_t
   >
 ::pressio::mpl::enable_if_t<
-     ::pressio::all_have_traits_and_same_scalar<A_type, B_type, C_type>::value
+  // level3 common constraints
+     ::pressio::Traits<A_type>::rank == 2
+  && ::pressio::Traits<B_type>::rank == 2
+  && ::pressio::Traits<C_type>::rank == 2
+  // TPL/container specific
   && ::pressio::is_multi_vector_tpetra<A_type>::value
   && ::pressio::is_multi_vector_tpetra<B_type>::value
-  && ::pressio::is_dense_matrix_eigen<C_type>::value,
+  && ::pressio::is_dynamic_dense_matrix_eigen<C_type>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<A_type, B_type, C_type>::value
+  && (std::is_floating_point<typename ::pressio::Traits<A_type>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<A_type>::scalar_type>::value)
+  && std::is_convertible<alpha_t, typename ::pressio::Traits<A_type>::scalar_type>::value,
   C_type
   >
 product(::pressio::transpose modeA,
@@ -162,9 +181,18 @@ template <
   class alpha_t, class beta_t
   >
 ::pressio::mpl::enable_if_t<
-     ::pressio::all_have_traits_and_same_scalar<A_type, C_type>::value
+  // level3 common constraints
+     ::pressio::Traits<A_type>::rank == 2
+  && ::pressio::Traits<C_type>::rank == 2
+  // TPL/container specific
   && ::pressio::is_multi_vector_tpetra<A_type>::value
   && ::pressio::is_dense_matrix_eigen<C_type>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<A_type, C_type>::value
+  && (std::is_floating_point<typename ::pressio::Traits<A_type>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<A_type>::scalar_type>::value)
+  && std::is_convertible<alpha_t, typename ::pressio::Traits<A_type>::scalar_type>::value
+  && std::is_convertible<beta_t,  typename ::pressio::Traits<A_type>::scalar_type>::value
   >
 product(::pressio::transpose /*unused*/,
 	::pressio::nontranspose /*unused*/,
@@ -202,9 +230,17 @@ product(::pressio::transpose /*unused*/,
 
 template <class C_type, class A_type, class alpha_t>
 ::pressio::mpl::enable_if_t<
-     ::pressio::all_have_traits_and_same_scalar<A_type, C_type>::value
+  // level3 common constraints
+     ::pressio::Traits<A_type>::rank == 2
+  && ::pressio::Traits<C_type>::rank == 2
+  // TPL/container specific
   && ::pressio::is_multi_vector_tpetra<A_type>::value
-  && ::pressio::is_dynamic_dense_matrix_eigen<C_type>::value,
+  && ::pressio::is_dynamic_dense_matrix_eigen<C_type>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<A_type, C_type>::value
+  && (std::is_floating_point<typename ::pressio::Traits<A_type>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<A_type>::scalar_type>::value)
+  && std::is_convertible<alpha_t, typename ::pressio::Traits<A_type>::scalar_type>::value,
   C_type
   >
 product(::pressio::transpose modeA,
@@ -230,9 +266,18 @@ C is a Kokkos dense matrix
 *-------------------------------------------------------------------*/
 template <class A_type, class C_type, class alpha_t, class beta_t>
 ::pressio::mpl::enable_if_t<
-  ::pressio::all_have_traits_and_same_scalar<A_type, C_type>::value
+  // level3 common constraints
+     ::pressio::Traits<A_type>::rank == 2
+  && ::pressio::Traits<C_type>::rank == 2
+  // TPL/container specific
   && ::pressio::is_multi_vector_tpetra<A_type>::value
   && ::pressio::is_dense_matrix_kokkos<C_type>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<A_type, C_type>::value
+  && (std::is_floating_point<typename ::pressio::Traits<A_type>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<A_type>::scalar_type>::value)
+  && std::is_convertible<alpha_t, typename ::pressio::Traits<A_type>::scalar_type>::value
+  && std::is_convertible<beta_t, typename ::pressio::Traits<A_type>::scalar_type>::value
   >
 product(::pressio::transpose /*unused*/,
 	::pressio::nontranspose /*unused*/,
@@ -270,9 +315,17 @@ C is a Kokkos dense matrix
 *-------------------------------------------------------------------*/
 template <class C_type, class A_type, class alpha_t>
 ::pressio::mpl::enable_if_t<
-  ::pressio::all_have_traits_and_same_scalar<A_type, C_type>::value
+  // level3 common constraints
+     ::pressio::Traits<A_type>::rank == 2
+  && ::pressio::Traits<C_type>::rank == 2
+  // TPL/container specific
   && ::pressio::is_multi_vector_tpetra<A_type>::value
-  && ::pressio::is_dense_matrix_kokkos<C_type>::value,
+  && ::pressio::is_dynamic_dense_matrix_kokkos<C_type>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<A_type, C_type>::value
+  && (std::is_floating_point<typename ::pressio::Traits<A_type>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<A_type>::scalar_type>::value)
+  && std::is_convertible<alpha_t, typename ::pressio::Traits<A_type>::scalar_type>::value,
   C_type
   >
 product(::pressio::transpose modeA,
@@ -295,17 +348,28 @@ A = tpetra multivector
 B = tpetra multivector
 C is a Kokkos dense matrix
 *-------------------------------------------------------------------*/
-template <class A_type, class C_type, class alpha_t, class beta_t>
+template <class A_type, class B_type, class C_type, class alpha_t, class beta_t>
 ::pressio::mpl::enable_if_t<
-  ::pressio::all_have_traits_and_same_scalar<A_type, C_type>::value
+  // level3 common constraints
+     ::pressio::Traits<A_type>::rank == 2
+  && ::pressio::Traits<B_type>::rank == 2
+  && ::pressio::Traits<C_type>::rank == 2
+  // TPL/container specific
   && ::pressio::is_multi_vector_tpetra<A_type>::value
+  && ::pressio::is_multi_vector_tpetra<B_type>::value
   && ::pressio::is_dense_matrix_kokkos<C_type>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<A_type, B_type, C_type>::value
+  && (std::is_floating_point<typename ::pressio::Traits<A_type>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<A_type>::scalar_type>::value)
+  && std::is_convertible<alpha_t, typename ::pressio::Traits<A_type>::scalar_type>::value
+  && std::is_convertible<beta_t,  typename ::pressio::Traits<A_type>::scalar_type>::value
   >
 product(::pressio::transpose /*unused*/,
 	::pressio::nontranspose /*unused*/,
 	const alpha_t & alpha,
 	const A_type & A,
-	const A_type & B,
+	const B_type & B,
 	const beta_t & beta,
 	C_type & C)
 {

--- a/include/pressio/ops/tpetra/ops_level3.hpp
+++ b/include/pressio/ops/tpetra/ops_level3.hpp
@@ -291,6 +291,9 @@ product(::pressio::transpose /*unused*/,
     (std::is_same< typename C_type::array_layout, Kokkos::LayoutLeft>::value,
      "The kokkos matrix must be layout left");
 
+  assert( (std::size_t)::pressio::ops::extent(C, 0) == (std::size_t) A.getNumVectors() );
+  assert( (std::size_t)::pressio::ops::extent(C, 1) == (std::size_t) A.getNumVectors() );
+
   using map_t      = typename A_type::map_type;
   // using tpetra_mv_t = typename ::pressio::Traits<A_type>::wrapped_type;
   const auto indexBase = A.getMap()->getIndexBase();
@@ -376,6 +379,10 @@ product(::pressio::transpose /*unused*/,
   static_assert
     (std::is_same< typename C_type::array_layout, Kokkos::LayoutLeft>::value,
      "The kokkos matrix must be layout left");
+
+  assert( (std::size_t)::pressio::ops::extent(A, 0) == (std::size_t)::pressio::ops::extent(B, 0));
+  assert( (std::size_t)::pressio::ops::extent(C, 0) == (std::size_t) A.getNumVectors() );
+  assert( (std::size_t)::pressio::ops::extent(C, 1) == (std::size_t) B.getNumVectors() );
 
   using map_t = typename A_type::map_type;
   const auto indexBase = A.getMap()->getIndexBase();

--- a/tests/functional_small/ops/ops_tpetra_level3.cc
+++ b/tests/functional_small/ops/ops_tpetra_level3.cc
@@ -26,14 +26,19 @@ TEST_F(tpetraMultiVectorGlobSize15Fixture, mv_T_mv_storein_eigen_C)
       pressio::nontranspose(),
       1.5, A, B, 1.0, C);
 
+  auto C2 = pressio::ops::product<Eigen::MatrixXd>(
+        pressio::transpose(), pressio::nontranspose(), 1.5, A, B);
+
   if(rank_==0){
     std::cout << C << std::endl;
+    std::cout << C2 << std::endl;
   }
 
   for (auto i=0; i<C.rows(); i++){
     for (auto j=0; j<C.cols(); j++){
       const auto gold = ac[i]*A.getGlobalLength()*1.5*bc[j];
       EXPECT_NEAR( C(i,j), gold, 1e-12);
+      EXPECT_NEAR( C2(i,j), gold, 1e-12);
     }
   }
 }


### PR DESCRIPTION
@fnrizzi 

refs #451

Contents
- [x] review overload constraints
- [x] add explicit alpha/beta casts
- [x] add missing unit tests for existing overloads
- [x] list overloads and test cases

### Overloads

Tpetra level-3 `pressio::ops::product()` (i.e. performing `C = alpha * op(A) * op(B) + beta * C`) overloads:

| `A` | `B` | `C` | op(A) | op(B) |
|:---:|:---:|:---:|:---:|:---:|
| tpetra MV | tpetra MV | eigen col-major matrix | `transpose` | `nontranspose` |
| tpetra MV | tpetra MV | dynamic&nbsp;eigen&nbsp;matrix<br> (returned&nbsp;value) | `transpose` | `nontranspose` |
| tpetra MV | ⨯<br> (self&nbsp;product) | eigen matrix | `transpose` | `nontranspose` |
| tpetra MV | ⨯<br> (self&nbsp;product) | dynamic&nbsp;eigen&nbsp;matrix<br> (returned&nbsp;value) | `transpose` | `nontranspose` |
| tpetra MV | ⨯<br> (self&nbsp;product) | kokkos&nbsp;dense&nbsp;matrix | `transpose` | `nontranspose` |
| tpetra MV | ⨯<br> (self&nbsp;product) | dynamic&nbsp;kokkos&nbsp;dense&nbsp;matrix<br> (returned&nbsp;value) | `transpose` | `nontranspose` |
| tpetra MV | tpetra MV | kokkos&nbsp;dense&nbsp;matrix | `transpose` | `nontranspose` |

### Test coverage

Test cases for Tpetra level-3 implementations of `pressio::ops::product()` (op(A) is always `transpose` and op(B) is always `nontranspose`):

| test | `A` | `B` | `C` |
|:---|:---|:---|:---|
| `mv_T_mv_storein_eigen_C`<br> `mv_T_mv_storein_eigen_C_beta0`<br> `mv_T_self_storein_eigen_C_test2` | `Tpetra::MultiVector` | `Tpetra::MultiVector` | `Eigen::MatrixXd` |
| `mv_T_self_storein_eigen_C`<br> `mv_T_self_storein_eigen_C_beta0` | `Tpetra::MultiVector` | ⨯ | `Eigen::MatrixXd` |
| `mv_T_self_storein_kokkos_C`<br> `mv_T_self_storein_kokkos_C_beta0` | `Tpetra::MultiVector` | ⨯ | `Kokkos::View<double**, Kokkos::LayoutLeft>` |
| `mv_T_mv_storein_kokkos_C`<br> `mv_T_mv_storein_kokkos_C_beta0` | `Tpetra::MultiVector` | `Tpetra::MultiVector` | `Kokkos::View<double**, Kokkos::LayoutLeft>` |
