### PR TITLE
 ops: epetra: revise matrix-matrix product

### DIFF
--- a/include/pressio/ops/epetra/ops_level3.hpp
+++ b/include/pressio/ops/epetra/ops_level3.hpp
@@ -64,19 +64,30 @@ B = epetra multivector
 C is an Eigen dense matrix
 *-------------------------------------------------------------------*/
 template <
-  typename A_type, typename B_type, typename scalar_type, typename C_type
+  typename A_type, typename B_type, typename alpha_type, typename beta_type, typename C_type
   >
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_multi_vector_epetra<A_type>::value and
-  ::pressio::is_multi_vector_epetra<B_type>::value and
-  ::pressio::is_dense_matrix_eigen<C_type>::value
+  // level3 common constraints
+     ::pressio::Traits<A_type>::rank == 2
+  && ::pressio::Traits<B_type>::rank == 2
+  && ::pressio::Traits<C_type>::rank == 2
+  // TPL/container specific
+  && ::pressio::is_multi_vector_epetra<A_type>::value
+  && ::pressio::is_multi_vector_epetra<B_type>::value
+  && ::pressio::is_dense_matrix_eigen<C_type>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<A_type, B_type, C_type>::value
+  && (std::is_floating_point<typename ::pressio::Traits<A_type>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<A_type>::scalar_type>::value)
+  && std::is_convertible<alpha_type, typename ::pressio::Traits<A_type>::scalar_type>::value
+  && std::is_convertible<beta_type,  typename ::pressio::Traits<A_type>::scalar_type>::value
   >
 product(::pressio::transpose /*unused*/,
 	::pressio::nontranspose /*unused*/,
-	const scalar_type alpha,
+	const alpha_type alpha,
 	const A_type & A,
 	const B_type & B,
-	const scalar_type beta,
+	const beta_type beta,
 	C_type & C)
 {
 
@@ -109,17 +120,27 @@ B = multivector
 C is an Eigen dense matrix returned by the function
 *-------------------------------------------------------------------*/
 template <
-  typename C_type, typename A_type, typename B_type, typename scalar_type
+  typename C_type, typename A_type, typename B_type, typename alpha_type
   >
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_multi_vector_epetra<A_type>::value and
-  ::pressio::is_multi_vector_epetra<B_type>::value and
-  ::pressio::is_dense_matrix_eigen<C_type>::value,
+  // level3 common constraints
+     ::pressio::Traits<A_type>::rank == 2
+  && ::pressio::Traits<B_type>::rank == 2
+  && ::pressio::Traits<C_type>::rank == 2
+  // TPL/container specific
+  && ::pressio::is_multi_vector_epetra<A_type>::value
+  && ::pressio::is_multi_vector_epetra<B_type>::value
+  && ::pressio::is_dynamic_dense_matrix_eigen<C_type>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<A_type, B_type, C_type>::value
+  && (std::is_floating_point<typename ::pressio::Traits<A_type>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<A_type>::scalar_type>::value)
+  && std::is_convertible<alpha_type, typename ::pressio::Traits<A_type>::scalar_type>::value,
   C_type
   >
 product(::pressio::transpose modeA,
  ::pressio::nontranspose modeB,
- const scalar_type alpha,
+ const alpha_type alpha,
  const A_type & A,
  const B_type & B)
 {
@@ -142,17 +163,27 @@ A = epetra multivector
 C is an Eigen dense matrix
 *-------------------------------------------------------------------*/
 template <
-  typename A_type, typename scalar_type, typename C_type
+  typename A_type, typename alpha_type, typename beta_type, typename C_type
   >
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_multi_vector_epetra<A_type>::value and
-  ::pressio::is_dense_matrix_eigen<C_type>::value
+  // level3 common constraints
+     ::pressio::Traits<A_type>::rank == 2
+  && ::pressio::Traits<C_type>::rank == 2
+  // TPL/container specific
+  && ::pressio::is_multi_vector_epetra<A_type>::value
+  && ::pressio::is_dense_matrix_eigen<C_type>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<A_type, C_type>::value
+  && (std::is_floating_point<typename ::pressio::Traits<A_type>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<A_type>::scalar_type>::value)
+  && std::is_convertible<alpha_type, typename ::pressio::Traits<A_type>::scalar_type>::value
+  && std::is_convertible<beta_type,  typename ::pressio::Traits<A_type>::scalar_type>::value
   >
 product(::pressio::transpose /*unused*/,
 	::pressio::nontranspose /*unused*/,
-	const scalar_type alpha,
+	const alpha_type alpha,
 	const A_type & A,
-	const scalar_type beta,
+	const beta_type beta,
 	C_type & C)
 {
 
@@ -188,16 +219,25 @@ product(::pressio::transpose /*unused*/,
 }
 
 template <
-  typename C_type, typename A_type, typename scalar_type
+  typename C_type, typename A_type, typename alpha_type
   >
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_multi_vector_epetra<A_type>::value and
-  ::pressio::is_dense_matrix_eigen<C_type>::value,
+  // level3 common constraints
+     ::pressio::Traits<A_type>::rank == 2
+  && ::pressio::Traits<C_type>::rank == 2
+  // TPL/container specific
+  && ::pressio::is_multi_vector_epetra<A_type>::value
+  && ::pressio::is_dynamic_dense_matrix_eigen<C_type>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<A_type, C_type>::value
+  && (std::is_floating_point<typename ::pressio::Traits<A_type>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<A_type>::scalar_type>::value)
+  && std::is_convertible<alpha_type, typename ::pressio::Traits<A_type>::scalar_type>::value,
   C_type
   >
 product(::pressio::transpose modeA,
 	::pressio::nontranspose modeB,
-	const scalar_type alpha,
+	const alpha_type alpha,
 	const A_type & A)
 {
 

--- a/include/pressio/ops/epetra/ops_level3.hpp
+++ b/include/pressio/ops/epetra/ops_level3.hpp
@@ -97,7 +97,10 @@ product(::pressio::transpose /*unused*/,
   assert( (std::size_t)::pressio::ops::extent(C,0) == (std::size_t)numVecsA );
   assert( (std::size_t)::pressio::ops::extent(C,1) == (std::size_t)numVecsB );
 
-  const auto zero = ::pressio::utils::Constants<scalar_type>::zero();
+  using sc_t = typename ::pressio::Traits<A_type>::scalar_type;
+  const auto zero = ::pressio::utils::Constants<sc_t>::zero();
+  const sc_t alpha_(alpha);
+  const sc_t beta_(beta);
   auto tmp = zero;
   // compute dot between every column of A with every col of B
   for (std::size_t i=0; i<(std::size_t)numVecsA; i++)
@@ -105,8 +108,8 @@ product(::pressio::transpose /*unused*/,
     for (std::size_t j=0; j<(std::size_t)numVecsB; j++)
     {
       A(i)->Dot( *(B(j)), &tmp );
-      tmp *= alpha;
-      C(i,j) = beta == zero ? zero :beta * C(i,j);
+      tmp *= alpha_;
+      C(i,j) = beta_ == zero ? zero : beta_ * C(i,j);
       C(i,j) += tmp;
     }
   }
@@ -144,7 +147,8 @@ product(::pressio::transpose modeA,
  const A_type & A,
  const B_type & B)
 {
-  constexpr auto zero = ::pressio::utils::Constants<scalar_type>::zero();
+  using sc_t = typename ::pressio::Traits<A_type>::scalar_type;
+  constexpr auto zero = ::pressio::utils::Constants<sc_t>::zero();
 
   const auto numVecsA = A.NumVectors();
   const auto numVecsB = B.NumVectors();
@@ -195,10 +199,13 @@ product(::pressio::transpose /*unused*/,
   assert(C.rows() == numVecsA);
   assert(C.cols() == numVecsA);
 
-  constexpr auto zero = ::pressio::utils::Constants<scalar_type>::zero();
-  scalar_type tmp = zero;
-  const auto apply_beta = [beta](scalar_type c) -> scalar_type {
-    return beta == zero ? zero : beta * c;
+  using sc_t = typename ::pressio::Traits<A_type>::scalar_type;
+  constexpr auto zero = ::pressio::utils::Constants<sc_t>::zero();
+  sc_t tmp = zero;
+  const sc_t alpha_(alpha);
+  const sc_t beta_(beta);
+  const auto apply_beta = [beta_](sc_t c) -> sc_t {
+    return beta_ == zero ? zero : beta_ * c;
   };
 
   // A dot A = A^T*A, which yields a symmetric matrix
@@ -207,7 +214,7 @@ product(::pressio::transpose /*unused*/,
   {
     C(i,i) = apply_beta(C(i,i));
     A(i)->Dot( *(A(i)), &tmp );
-    C(i,i) += alpha*tmp;
+    C(i,i) += alpha_*tmp;
 
     for (int j=i+1; j<numVecsA; j++)
     {
@@ -215,8 +222,8 @@ product(::pressio::transpose /*unused*/,
       C(j,i) = apply_beta(C(j,i));
 
       A(i)->Dot( *(A(j)), &tmp );
-      C(i,j) += alpha*tmp;
-      C(j,i) += alpha*tmp;
+      C(i,j) += alpha_*tmp;
+      C(j,i) += alpha_*tmp;
     }
   }
 }
@@ -243,8 +250,8 @@ product(::pressio::transpose modeA,
 	const alpha_type alpha,
 	const A_type & A)
 {
-
-  constexpr auto zero = ::pressio::utils::Constants<scalar_type>::zero();
+  using sc_t = typename ::pressio::Traits<A_type>::scalar_type;
+  constexpr auto zero = ::pressio::utils::Constants<sc_t>::zero();
   C_type C(A.NumVectors(), A.NumVectors());
   product(modeA, modeB, alpha, A, zero, C);
   return C;

--- a/include/pressio/ops/epetra/ops_level3.hpp
+++ b/include/pressio/ops/epetra/ops_level3.hpp
@@ -187,6 +187,9 @@ product(::pressio::transpose /*unused*/,
 	C_type & C)
 {
 
+  assert( ::pressio::ops::extent(C, 0) == ::pressio::ops::extent(A, 1) );
+  assert( ::pressio::ops::extent(C, 1) == ::pressio::ops::extent(A, 1) );
+
   // how many vectors are in A and B
   const int numVecsA = A.NumVectors();
   assert(C.rows() == numVecsA);

--- a/tests/functional_small/ops/ops_epetra_level3.cc
+++ b/tests/functional_small/ops/ops_epetra_level3.cc
@@ -84,14 +84,19 @@ TEST_F(epetraMultiVectorGlobSize15Fixture, mv_T_self_storein_eigen_C)
     pressio::ops::product(pressio::transpose(), pressio::nontranspose(),
         1.5, A, 1.0, C);
 
+    auto C2 = pressio::ops::product<Eigen::MatrixXd>(pressio::transpose(), pressio::nontranspose(),
+        1.5, A);
+
     if(rank_==0){
         std::cout << C << std::endl;
+        std::cout << C2 << std::endl;
     }
 
     for (auto i=0; i<C.rows(); i++){
         for (auto j=0; j<C.cols(); j++){
             const auto gold = ac[i]*A.GlobalLength()*1.5*ac[j];
             EXPECT_NEAR( C(i,j), gold, 1e-12);
+            EXPECT_NEAR( C2(i,j), gold, 1e-12);
         }
     }
 }


### PR DESCRIPTION
@fnrizzi

refs #451

Contents
- [x] review overload constraints
- [x] add explicit alpha/beta casts
- [x] add missing unit tests for existing overloads
- [x] list overloads and test cases

### Overloads

Epetra level-3 `pressio::ops::product()` (i.e. performing `C = alpha * op(A) * op(B) + beta * C`) overloads:

| `A` | `B` | `C` | op(A) | op(B) |
|:---:|:---:|:---:|:---:|:---:|
| epetra MV | epetra MV | eigen matrix | `transpose` | `nontranspose` |
| epetra MV | epetra MV | dynamic&nbsp;eigen&nbsp;matrix<br> (returned&nbsp;value) | `transpose` | `nontranspose` |
| epetra MV | ⨯<br> (self&nbsp;product) | eigen matrix | `transpose` | `nontranspose` |
| epetra MV | ⨯<br> (self&nbsp;product) | dynamic&nbsp;eigen&nbsp;matrix<br> (returned&nbsp;value) | `transpose` | `nontranspose` |

### Test coverage

Test cases for Epetra level-3 implementations of `pressio::ops::product()` (op(A) is always `transpose` and op(B) is always `nontranspose`):

| test | `A` | `B` | `C` |
|:---|:---|:---|:---|
| `mv_T_mv_storein_eigen_C`<br> `mv_T_mv_storein_eigen_C_beta0` | `Epetra_MultiVector` | `Epetra_MultiVector` | `Eigen::MatrixXd` |
| `mv_T_self_storein_eigen_C`<br> `mv_T_self_storein_eigen_C_beta0` | `Epetra_MultiVector` | ⨯ | `Eigen::MatrixXd` |
