### PR TITLE
ops: tpetra-block: revise matrix-matrix product

### DIFF
--- a/include/pressio/ops/tpetra_block/ops_level3.hpp
+++ b/include/pressio/ops/tpetra_block/ops_level3.hpp
@@ -67,10 +67,20 @@ template <
   class A_type, class B_type, class C_type, class alpha_t, class beta_t
   >
 ::pressio::mpl::enable_if_t<
-  ::pressio::all_have_traits_and_same_scalar<A_type, C_type, B_type>::value
+  // level3 common constraints
+     ::pressio::Traits<A_type>::rank == 2
+  && ::pressio::Traits<B_type>::rank == 2
+  && ::pressio::Traits<C_type>::rank == 2
+  // TPL/container specific
   && ::pressio::is_multi_vector_tpetra_block<A_type>::value
   && ::pressio::is_multi_vector_tpetra_block<B_type>::value
-  && ::pressio::is_dense_matrix_eigen<C_type>::value
+  && ::pressio::is_dense_col_major_matrix_eigen<C_type>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<A_type, B_type, C_type>::value
+  && (std::is_floating_point<typename ::pressio::Traits<A_type>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<A_type>::scalar_type>::value)
+  && std::is_convertible<alpha_t, typename ::pressio::Traits<A_type>::scalar_type>::value
+  && std::is_convertible<beta_t,  typename ::pressio::Traits<A_type>::scalar_type>::value
   >
 product(::pressio::transpose modeA,
 	::pressio::nontranspose modeB,
@@ -96,10 +106,19 @@ template <
   class C_type, class A_type, class B_type, class alpha_t
   >
 ::pressio::mpl::enable_if_t<
-  ::pressio::all_have_traits_and_same_scalar<A_type, C_type, B_type>::value
+  // level3 common constraints
+     ::pressio::Traits<A_type>::rank == 2
+  && ::pressio::Traits<B_type>::rank == 2
+  && ::pressio::Traits<C_type>::rank == 2
+  // TPL/container specific
   && ::pressio::is_multi_vector_tpetra_block<A_type>::value
   && ::pressio::is_multi_vector_tpetra_block<B_type>::value
-  && ::pressio::is_dense_matrix_eigen<C_type>::value,
+  && ::pressio::is_dynamic_dense_matrix_eigen<C_type>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<A_type, B_type, C_type>::value
+  && (std::is_floating_point<typename ::pressio::Traits<A_type>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<A_type>::scalar_type>::value)
+  && std::is_convertible<alpha_t, typename ::pressio::Traits<A_type>::scalar_type>::value,
   C_type
   >
 product(::pressio::transpose modeA,
@@ -121,9 +140,17 @@ template <
   class A_type, class C_type, class alpha_t, class beta_t
   >
 ::pressio::mpl::enable_if_t<
-  ::pressio::all_have_traits_and_same_scalar<A_type, C_type>::value
+  // level3 common constraints
+     ::pressio::Traits<A_type>::rank == 2
+  && ::pressio::Traits<C_type>::rank == 2
+  // TPL/container specific
   && ::pressio::is_multi_vector_tpetra_block<A_type>::value
   && ::pressio::is_dense_matrix_eigen<C_type>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<A_type, C_type>::value
+  && (std::is_floating_point<typename ::pressio::Traits<A_type>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<A_type>::scalar_type>::value)
+  && std::is_convertible<alpha_t, typename ::pressio::Traits<A_type>::scalar_type>::value
   >
 product(::pressio::transpose modeA,
 	::pressio::nontranspose modeB,
@@ -140,9 +167,17 @@ template <
   class C_type, class A_type, class alpha_t
   >
 ::pressio::mpl::enable_if_t<
-  ::pressio::all_have_traits_and_same_scalar<A_type, C_type>::value
+  // level3 common constraints
+     ::pressio::Traits<A_type>::rank == 2
+  && ::pressio::Traits<C_type>::rank == 2
+  // TPL/container specific
   && ::pressio::is_multi_vector_tpetra_block<A_type>::value
-  && ::pressio::is_dynamic_dense_matrix_eigen<C_type>::value,
+  && ::pressio::is_dynamic_dense_matrix_eigen<C_type>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<A_type, C_type>::value
+  && (std::is_floating_point<typename ::pressio::Traits<A_type>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<A_type>::scalar_type>::value)
+  && std::is_convertible<alpha_t, typename ::pressio::Traits<A_type>::scalar_type>::value,
   C_type
   >
 product(::pressio::transpose modeA,
@@ -166,9 +201,18 @@ template <
   class A_type, class C_type, class alpha_t, class beta_t
   >
 ::pressio::mpl::enable_if_t<
-  ::pressio::all_have_traits_and_same_scalar<A_type, C_type>::value
+  // level3 common constraints
+     ::pressio::Traits<A_type>::rank == 2
+  && ::pressio::Traits<C_type>::rank == 2
+  // TPL/container specific
   && ::pressio::is_multi_vector_tpetra_block<A_type>::value
   && ::pressio::is_dense_matrix_kokkos<C_type>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<A_type, C_type>::value
+  && (std::is_floating_point<typename ::pressio::Traits<A_type>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<A_type>::scalar_type>::value)
+  && std::is_convertible<alpha_t, typename ::pressio::Traits<A_type>::scalar_type>::value
+  && std::is_convertible<beta_t,  typename ::pressio::Traits<A_type>::scalar_type>::value
   >
 product(::pressio::transpose modeA,
 	::pressio::nontranspose modeB,
@@ -189,9 +233,17 @@ product(::pressio::transpose modeA,
    *-------------------------------------------------------------------*/
 template <class C_type, class A_type, class alpha_t>
 ::pressio::mpl::enable_if_t<
-  ::pressio::all_have_traits_and_same_scalar<A_type, C_type>::value
+  // level3 common constraints
+     ::pressio::Traits<A_type>::rank == 2
+  && ::pressio::Traits<C_type>::rank == 2
+  // TPL/container specific
   && ::pressio::is_multi_vector_tpetra_block<A_type>::value
-  && ::pressio::is_dense_matrix_kokkos<C_type>::value,
+  && ::pressio::is_dynamic_dense_matrix_kokkos<C_type>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<A_type, C_type>::value
+  && (std::is_floating_point<typename ::pressio::Traits<A_type>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<A_type>::scalar_type>::value)
+  && std::is_convertible<alpha_t, typename ::pressio::Traits<A_type>::scalar_type>::value,
   C_type
   >
 product(::pressio::transpose modeA,
@@ -212,9 +264,18 @@ C is a Kokkos dense matrix
 *-------------------------------------------------------------------*/
 template <class A_type, class C_type, class alpha_t, class beta_t>
 ::pressio::mpl::enable_if_t<
-  ::pressio::all_have_traits_and_same_scalar<A_type, C_type>::value
+  // level3 common constraints
+     ::pressio::Traits<A_type>::rank == 2
+  && ::pressio::Traits<C_type>::rank == 2
+  // TPL/container specific
   && ::pressio::is_multi_vector_tpetra_block<A_type>::value
   && ::pressio::is_dense_matrix_kokkos<C_type>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<A_type, C_type>::value
+  && (std::is_floating_point<typename ::pressio::Traits<A_type>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<A_type>::scalar_type>::value)
+  && std::is_convertible<alpha_t, typename ::pressio::Traits<A_type>::scalar_type>::value
+  && std::is_convertible<beta_t,  typename ::pressio::Traits<A_type>::scalar_type>::value
   >
 product(::pressio::transpose modeA,
 	::pressio::nontranspose modeB,

--- a/tests/functional_small/ops/fixtures/tpetra_block_only_fixtures.hpp
+++ b/tests/functional_small/ops/fixtures/tpetra_block_only_fixtures.hpp
@@ -9,6 +9,8 @@
 #include <Teuchos_CommHelpers.hpp>
 #include <Tpetra_Map_decl.hpp>
 
+#include "pressio/ops.hpp"
+
 /* the tpetra data structures below are
  * left without templates such that it picks
  * up the default. So if kokkos is built with
@@ -76,9 +78,18 @@ public:
   Teuchos::RCP<const tcomm> comm_;
   Teuchos::RCP<const map_t> contigMap_;
 
+  // level2
   std::shared_ptr<mvec_t> myMv_;
   std::shared_ptr<vec_t> x_tpetra;
   std::shared_ptr<vec_t> y_tpetra;
+
+  // level3
+  decltype(::pressio::ops::clone(*myMv_)) A;
+  std::shared_ptr<mvec_t> B;
+  static std::array<double, 4> ac;
+  static std::array<double, 3> bc;
+  Eigen::MatrixXd C_eigen;
+  Kokkos::View<double**, Kokkos::LayoutLeft> C_kokkos;
 
   virtual void SetUp(){
     MPI_Comm_rank(MPI_COMM_WORLD, &rank_);
@@ -106,9 +117,33 @@ public:
     }
     y_tpetra = std::make_shared<vec_t>(*contigMap_, blockSize_);
 
+    // level3 data
+    A = pressio::ops::clone(*myMv_);
+    for (decltype(A.getNumVectors()) i=0; i<A.getNumVectors(); ++i) {
+      A.getMultiVectorView().getVectorNonConst(i)->putScalar(ac[i]);
+    }
+    B = std::make_shared<mvec_t>(*contigMap_, blockSize_, bc.size());
+    for (int i=0; i<bc.size(); ++i) {
+      B->getMultiVectorView().getVectorNonConst(i)->putScalar(bc[i]);
+    }
+    C_eigen = Eigen::MatrixXd(A.getNumVectors(), A.getNumVectors());
+    C_eigen.setConstant(0.);
+    C_kokkos = Kokkos::View<double**, Kokkos::LayoutLeft>("C", A.getNumVectors(), A.getNumVectors());
+    Kokkos::deep_copy(C_kokkos, 0.);
   }
 
   virtual void TearDown(){}
+
+  auto gold_a(size_t i, size_t j) {
+      return ac[i]*A.getMultiVectorView().getGlobalLength()*1.5*ac[j];
+  }
+
+  auto gold_ab(size_t i, size_t j) {
+      return ac[i]*A.getMultiVectorView().getGlobalLength()*1.5*bc[j];
+  }
 };
+
+std::array<double, 4> tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture::ac{1.,2.,3.,4.};
+std::array<double, 3> tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture::bc{1.2, 2.2, 3.2};
 
 #endif

--- a/tests/functional_small/ops/ops_tpetra_block_level3.cc
+++ b/tests/functional_small/ops/ops_tpetra_block_level3.cc
@@ -6,30 +6,14 @@
 TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
        mv_T_mv_storein_eigen_C)
 {
-  auto A = pressio::ops::clone(*myMv_);
-  std::array<double, 4> ac{1.,2.,3.,4.};
-  for (std::size_t i=0; i<A.getMultiVectorView().getNumVectors(); ++i) {
-    A.getMultiVectorView().getVectorNonConst(i)->putScalar(ac[i]);
-  }
-
-  mvec_t B(*contigMap_, blockSize_, 4);
-  std::array<double, 4> bc{1.2, 2.2, 3.2, -4.1};
-  for (int i=0; i<4; ++i) {
-    B.getMultiVectorView().getVectorNonConst(i)->putScalar(bc[i]);
-  }
-
-  Eigen::MatrixXd C(A.getNumVectors(), B.getNumVectors());
-  C.setConstant(0.);
-
   // C = 1*C + 1.5 A^T B
   pressio::ops::product(pressio::transpose(),
 			pressio::nontranspose(),
-			1.5, A, B, 1.0, C);
+			1.5, A, *B, 1.0, C_eigen);
 
-  for (auto i=0; i<C.rows(); i++){
-    for (auto j=0; j<C.cols(); j++){
-      const auto gold = ac[i]*A.getMultiVectorView().getGlobalLength()*1.5*bc[j];
-      EXPECT_NEAR( C(i,j), gold, 1e-12);
+  for (auto i = 0; i < C_eigen.rows(); i++){
+    for (auto j = 0; j < C_eigen.cols(); j++){
+      EXPECT_NEAR(C_eigen(i, j), gold_ab(i, j), 1e-12);
     }
   }
 }
@@ -37,28 +21,18 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
 TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
        mv_T_self_storein_eigen_C)
 {
-  auto A = pressio::ops::clone(*myMv_);
-  std::array<double, 4> ac{1.,2.,3.,4.};
-  for (std::size_t i=0; i<A.getMultiVectorView().getNumVectors(); ++i) {
-    A.getMultiVectorView().getVectorNonConst(i)->putScalar(ac[i]);
-  }
-
-  Eigen::MatrixXd C(A.getNumVectors(), A.getNumVectors());
-  C.setConstant(0.);
-
   // C = 1*C + 1.5 A^T A
   pressio::ops::product(pressio::transpose(),
 			pressio::nontranspose(),
-			1.5, A, 1.0, C);
+			1.5, A, 1.0, C_eigen);
 
   if(rank_==0){
-    std::cout << C << std::endl;
+    std::cout << C_eigen << std::endl;
   }
 
-  for (auto i=0; i<C.rows(); i++){
-    for (auto j=0; j<C.cols(); j++){
-      const auto gold = ac[i]*A.getMultiVectorView().getGlobalLength()*1.5*ac[j];
-      EXPECT_NEAR( C(i,j), gold, 1e-12);
+  for (auto i = 0; i < C_eigen.rows(); i++){
+    for (auto j = 0; j < C_eigen.cols(); j++){
+      EXPECT_NEAR(C_eigen(i, j), gold_a(i, j), 1e-12);
     }
   }
 }
@@ -66,18 +40,6 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
 TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
        mv_T_self_create_result_eigen_C)
 {
-  auto A = pressio::ops::clone(*myMv_);
-  std::array<double, 4> ac{1.,2.,3.,4.};
-  for (std::size_t i=0; i<A.getMultiVectorView().getNumVectors(); ++i) {
-    A.getMultiVectorView().getVectorNonConst(i)->putScalar(ac[i]);
-  }
-
-  mvec_t B(*contigMap_, blockSize_, 4);
-  std::array<double, 4> bc{1.2, 2.2, 3.2, -4.1};
-  for (int i=0; i<4; ++i) {
-    B.getMultiVectorView().getVectorNonConst(i)->putScalar(bc[i]);
-  }
-
   // C = 1.5 A^T A
   auto C = pressio::ops::product<Eigen::MatrixXd>(pressio::transpose(),
 						  pressio::nontranspose(),
@@ -85,18 +47,17 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
 
   auto C2 = pressio::ops::product<Eigen::MatrixXd>(pressio::transpose(),
 						  pressio::nontranspose(),
-						  1.5, A, B);
+						  1.5, A, *B);
 
   if(rank_==0){
-    std::cout << C << "\n\n" << C2 << std::endl;
+    std::cout << C << "\n\n"
+              << C2 << std::endl;
   }
 
   for (auto i=0; i<C.rows(); i++){
     for (auto j=0; j<C.cols(); j++){
-      const auto gold = ac[i]*A.getMultiVectorView().getGlobalLength()*1.5*ac[j];
-      EXPECT_NEAR( C(i,j), gold, 1e-12);
-      const auto gold2 = ac[i]*A.getMultiVectorView().getGlobalLength()*1.5*bc[j];
-      EXPECT_NEAR( C2(i,j), gold, 1e-12);
+      EXPECT_NEAR(C(i, j), gold_a(i, j), 1e-12);
+      EXPECT_NEAR(C2(i, j), gold_ab(i, j), 1e-12);
     }
   }
 }
@@ -104,61 +65,43 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
 TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
        mv_T_self_storein_eigen_C_beta0)
 {
-  auto A = pressio::ops::clone(*myMv_);
-  std::array<double, 4> ac{1.,2.,3.,4.};
-  for (std::size_t i=0; i<A.getMultiVectorView().getNumVectors(); ++i) {
-    A.getMultiVectorView().getVectorNonConst(i)->putScalar(ac[i]);
-  }
-
-  Eigen::MatrixXd C(A.getNumVectors(), A.getNumVectors());
-  C.setConstant(std::nan("0"));
+  C_eigen.setConstant(std::nan("0"));
 
   // C = 0*NAN + 1.5 A^T A
   pressio::ops::product(pressio::transpose(),
 			pressio::nontranspose(),
-			1.5, A, 0.0, C);
+			1.5, A, 0.0, C_eigen);
 
   if(rank_==0){
-    std::cout << C << std::endl;
+    std::cout << C_eigen << std::endl;
   }
 
-  for (auto i=0; i<C.rows(); i++){
-    for (auto j=0; j<C.cols(); j++){
-      const auto gold = ac[i]*A.getMultiVectorView().getGlobalLength()*1.5*ac[j];
-      EXPECT_NEAR( C(i,j), gold, 1e-12);
+  for (auto i = 0; i < C_eigen.rows(); i++){
+    for (auto j = 0; j < C_eigen.cols(); j++){
+      EXPECT_NEAR(C_eigen(i, j), gold_a(i, j), 1e-12);
     }
   }
 }
 #endif
 
-
 TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
        mv_T_self_storein_kokkos_C)
 {
-  auto A = pressio::ops::clone(*myMv_);
-  std::array<double, 4> ac{1.,2.,3.,4.};
-  for (decltype(A.getNumVectors()) i=0; i<A.getNumVectors(); ++i) {
-    A.getMultiVectorView().getVectorNonConst(i)->putScalar(ac[i]);
-  }
-
-  Kokkos::View<double**, Kokkos::LayoutLeft> C("C", A.getNumVectors(), A.getNumVectors());
-
   // C = 1*C + 1.5 A^T A
   pressio::ops::product(pressio::transpose(),
 			pressio::nontranspose(),
-			1.5, A, 1.0, C);
+			1.5, A, 1.0, C_kokkos);
 
-  auto C2 = pressio::ops::product<
+  auto C2_kokkos = pressio::ops::product<
     Kokkos::View<double**, Kokkos::LayoutLeft>>(pressio::transpose(),
 						pressio::nontranspose(), 1.5, A);
 
-  auto C_h = Kokkos::create_mirror_view(C);
-  auto C2_h = Kokkos::create_mirror_view(C2);
-  for (std::size_t i=0; i<C.extent(0); i++){
-    for (std::size_t j=0; j<C.extent(1); j++){
-      const auto gold = ac[i]*A.getMultiVectorView().getGlobalLength()*1.5*ac[j];
-      EXPECT_NEAR( C_h(i,j), gold, 1e-12);
-      EXPECT_NEAR( C2_h(i,j), gold, 1e-12);
+  auto C_h = Kokkos::create_mirror_view(C_kokkos);
+  auto C2_h = Kokkos::create_mirror_view(C2_kokkos);
+  for (std::size_t i = 0; i < C_kokkos.extent(0); i++){
+    for (std::size_t j = 0; j < C_kokkos.extent(1); j++){
+      EXPECT_NEAR(C_h(i, j), gold_a(i, j), 1e-12);
+      EXPECT_NEAR(C2_h(i, j), gold_a(i, j), 1e-12);
     }
   }
 }
@@ -166,31 +109,23 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
 TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
        mv_T_self_storein_kokkos_C_beta0)
 {
-  auto A = pressio::ops::clone(*myMv_);
-  std::array<double, 4> ac{1.,2.,3.,4.};
-  for (decltype(A.getNumVectors()) i=0; i<A.getNumVectors(); ++i) {
-    A.getMultiVectorView().getVectorNonConst(i)->putScalar(ac[i]);
-  }
-
-  Kokkos::View<double**, Kokkos::LayoutLeft> C("C", A.getNumVectors(), A.getNumVectors());
-  Kokkos::deep_copy(C, std::nan("0"));
+  Kokkos::deep_copy(C_kokkos, std::nan("0"));
 
   // C = 0*NAN + 1.5 A^T A
   pressio::ops::product(pressio::transpose(),
 			pressio::nontranspose(),
-			1.5, A, 0.0, C);
+			1.5, A, 0.0, C_kokkos);
 
-  auto C2 = pressio::ops::product<
+  auto C2_kokkos = pressio::ops::product<
     Kokkos::View<double**, Kokkos::LayoutLeft>>(pressio::transpose(),
 						pressio::nontranspose(), 1.5, A);
 
-  auto C_h = Kokkos::create_mirror_view(C);
-  auto C2_h = Kokkos::create_mirror_view(C2);
-  for (std::size_t i=0; i<C.extent(0); i++){
-    for (std::size_t j=0; j<C.extent(1); j++){
-      const auto gold = ac[i]*A.getMultiVectorView().getGlobalLength()*1.5*ac[j];
-      EXPECT_NEAR( C_h(i,j), gold, 1e-12);
-      EXPECT_NEAR( C2_h(i,j), gold, 1e-12);
+  auto C_h = Kokkos::create_mirror_view(C_kokkos);
+  auto C2_h = Kokkos::create_mirror_view(C2_kokkos);
+  for (std::size_t i = 0; i < C_kokkos.extent(0); i++){
+    for (std::size_t j = 0; j < C_kokkos.extent(1); j++){
+      EXPECT_NEAR(C_h(i, j), gold_a(i, j), 1e-12);
+      EXPECT_NEAR(C2_h(i, j), gold_a(i, j), 1e-12);
     }
   }
 }
@@ -198,30 +133,15 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
 TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
        mv_T_mv_storein_kokkos_C)
 {
-  auto A = pressio::ops::clone(*myMv_);
-  std::array<double, 4> ac{1.,2.,3.,4.};
-  for (decltype(A.getNumVectors()) i=0; i<A.getNumVectors(); ++i) {
-    A.getMultiVectorView().getVectorNonConst(i)->putScalar(ac[i]);
-  }
-
-  mvec_t B(*contigMap_, blockSize_, 3);
-  std::array<double, 3> bc{1.2, 2.2, 3.2};
-  for (int i=0; i<3; ++i) {
-    B.getMultiVectorView().getVectorNonConst(i)->putScalar(bc[i]);
-  }
-
-  Kokkos::View<double**, Kokkos::LayoutLeft> C("C", A.getNumVectors(), B.getNumVectors());
-
   // C = 1*C + 1.5 A^T B
   pressio::ops::product(pressio::transpose(),
 			pressio::nontranspose(),
-			1.5, A, B, 1.0, C);
+			1.5, A, *B, 1.0, C_kokkos);
 
-  auto C_h = Kokkos::create_mirror_view(C);
-  for (std::size_t i=0; i<C.extent(0); i++){
-    for (std::size_t j=0; j<C.extent(1); j++){
-      const auto gold = ac[i]*A.getMultiVectorView().getGlobalLength()*1.5*bc[j];
-      EXPECT_NEAR( C_h(i,j), gold, 1e-12);
+  auto C_h = Kokkos::create_mirror_view(C_kokkos);
+  for (std::size_t i = 0; i < C_kokkos.extent(0); i++){
+    for (std::size_t j = 0; j < C_kokkos.extent(1); j++){
+      EXPECT_NEAR(C_h(i, j), gold_ab(i, j), 1e-12);
     }
   }
 }
@@ -229,31 +149,17 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
 TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
        mv_T_mv_storein_kokkos_C_beta0)
 {
-  auto A = pressio::ops::clone(*myMv_);
-  std::array<double, 4> ac{1.,2.,3.,4.};
-  for (decltype(A.getNumVectors()) i=0; i<A.getNumVectors(); ++i) {
-    A.getMultiVectorView().getVectorNonConst(i)->putScalar(ac[i]);
-  }
-
-  mvec_t B(*contigMap_, blockSize_, 3);
-  std::array<double, 3> bc{1.2, 2.2, 3.2};
-  for (int i=0; i<3; ++i) {
-    B.getMultiVectorView().getVectorNonConst(i)->putScalar(bc[i]);
-  }
-
-  Kokkos::View<double**, Kokkos::LayoutLeft> C("C", A.getNumVectors(), B.getNumVectors());
-  Kokkos::deep_copy(C, std::nan("0"));
+  Kokkos::deep_copy(C_kokkos, std::nan("0"));
 
   // C = 0*NAN + 1.5 A^T B
   pressio::ops::product(pressio::transpose(),
 			pressio::nontranspose(),
-			1.5, A, B, 0.0, C);
+			1.5, A, *B, 0.0, C_kokkos);
 
-  auto C_h = Kokkos::create_mirror_view(C);
-  for (std::size_t i=0; i<C.extent(0); i++){
-    for (std::size_t j=0; j<C.extent(1); j++){
-      const auto gold = ac[i]*A.getMultiVectorView().getGlobalLength()*1.5*bc[j];
-      EXPECT_NEAR( C_h(i,j), gold, 1e-12);
+  auto C_h = Kokkos::create_mirror_view(C_kokkos);
+  for (std::size_t i = 0; i < C_kokkos.extent(0); i++){
+    for (std::size_t j = 0; j < C_kokkos.extent(1); j++){
+      EXPECT_NEAR(C_h(i, j), gold_ab(i, j), 1e-12);
     }
   }
 }

--- a/tests/functional_small/ops/ops_tpetra_block_level3.cc
+++ b/tests/functional_small/ops/ops_tpetra_block_level3.cc
@@ -72,19 +72,31 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture,
     A.getMultiVectorView().getVectorNonConst(i)->putScalar(ac[i]);
   }
 
+  mvec_t B(*contigMap_, blockSize_, 4);
+  std::array<double, 4> bc{1.2, 2.2, 3.2, -4.1};
+  for (int i=0; i<4; ++i) {
+    B.getMultiVectorView().getVectorNonConst(i)->putScalar(bc[i]);
+  }
+
   // C = 1.5 A^T A
   auto C = pressio::ops::product<Eigen::MatrixXd>(pressio::transpose(),
 						  pressio::nontranspose(),
 						  1.5, A);
 
+  auto C2 = pressio::ops::product<Eigen::MatrixXd>(pressio::transpose(),
+						  pressio::nontranspose(),
+						  1.5, A, B);
+
   if(rank_==0){
-    std::cout << C << std::endl;
+    std::cout << C << "\n\n" << C2 << std::endl;
   }
 
   for (auto i=0; i<C.rows(); i++){
     for (auto j=0; j<C.cols(); j++){
       const auto gold = ac[i]*A.getMultiVectorView().getGlobalLength()*1.5*ac[j];
       EXPECT_NEAR( C(i,j), gold, 1e-12);
+      const auto gold2 = ac[i]*A.getMultiVectorView().getGlobalLength()*1.5*bc[j];
+      EXPECT_NEAR( C2(i,j), gold, 1e-12);
     }
   }
 }


### PR DESCRIPTION
@fnrizzi 

refs #451

Contents
- [x] review overload constraints
- [x] add missing unit tests for existing overloads
- [x] refactor unit test fixtures
- [x] list overloads and test cases

### Overloads

Tpetra-block level-3 `pressio::ops::product()` (i.e. performing `C = alpha * op(A) * op(B) + beta * C`) overloads:

| `A` | `B` | `C` | op(A) | op(B) |
|:---:|:---:|:---:|:---:|:---:|
| tpetra MV-block | tpetra MV-block | eigen col-major matrix | `transpose` | `nontranspose` |
| tpetra MV-block | tpetra MV-block | dynamic&nbsp;eigen&nbsp;matrix<br> (returned&nbsp;value) | `transpose` | `nontranspose` |
| tpetra MV-block | ⨯<br> (self&nbsp;product) | eigen matrix | `transpose` | `nontranspose` |
| tpetra MV-block | ⨯<br> (self&nbsp;product) | dynamic&nbsp;eigen&nbsp;matrix<br> (returned&nbsp;value) | `transpose` | `nontranspose` |
| tpetra MV-block | ⨯<br> (self&nbsp;product) | kokkos&nbsp;dense&nbsp;matrix | `transpose` | `nontranspose` |
| tpetra MV-block | ⨯<br> (self&nbsp;product) | dynamic&nbsp;kokkos&nbsp;dense&nbsp;matrix<br> (returned&nbsp;value) | `transpose` | `nontranspose` |
| tpetra MV-block | tpetra MV-block | kokkos&nbsp;dense&nbsp;matrix | `transpose` | `nontranspose` |

### Test coverage

Test cases for Tpetra-block level-3 implementations of `pressio::ops::product()` (op(A) is always `transpose` and op(B) is always `nontranspose`):

| test | `A` | `B` | `C` |
|:---|:---|:---|:---|
| `mv_T_mv_storein_eigen_C` | `Tpetra::BlockMultiVector` | `Tpetra::BlockMultiVector` | `Eigen::MatrixXd` |
| `mv_T_self_storein_eigen_C` | `Tpetra::BlockMultiVector` | ⨯ | `Eigen::MatrixXd` |
| `mv_T_self_create_result_eigen_C`<br> `mv_T_self_storein_eigen_C_beta0` | `Tpetra::BlockMultiVector` | `Tpetra::BlockMultiVector` | `Eigen::MatrixXd` |
| `mv_T_self_storein_kokkos_C`<br> `mv_T_self_storein_kokkos_C_beta0` | `Tpetra::BlockMultiVector` | ⨯ | `Kokkos::View<double**, Kokkos::LayoutLeft>` |
| `mv_T_mv_storein_kokkos_C`<br> `mv_T_mv_storein_kokkos_C_beta0` | `Tpetra::BlockMultiVector` | `Tpetra::BlockMultiVector` | `Kokkos::View<double**, Kokkos::LayoutLeft>` |