### PR TITLE
 ops: epetra: revise rank-1 update

### DIFF
--- a/include/pressio/ops/epetra/ops_rank1_update.hpp
+++ b/include/pressio/ops/epetra/ops_rank1_update.hpp
@@ -70,11 +70,21 @@ update(T & v,        const scalar_t a,
 {
   assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v1, 0));
 
+  const auto zero = ::pressio::utils::Constants<scalar_t>::zero();
   scalar_t a_{a};
   scalar_t b_{b};
 
-  for (int i=0; i<v.MyLength(); ++i)
-    v[i] = a_*v[i] + b_*v1[i];
+  if (b_ == zero) {
+    ::pressio::ops::scale(v, a_);
+  } else {
+    for (int i=0; i<v.MyLength(); ++i) {
+      if (a_ == zero) {
+        v[i] = b_*v1[i];
+      } else {
+        v[i] = a_*v[i] + b_*v1[i];
+      }
+    }
+  }
 }
 
 //----------------------------------------------------------------------
@@ -98,12 +108,24 @@ update(T & v,     const scalar_t &a,
   assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v1, 0));
   assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v2, 0));
 
+  const auto zero = ::pressio::utils::Constants<scalar_t>::zero();
   scalar_t a_{a};
   scalar_t b_{b};
   scalar_t c_{c};
 
-  for (int i=0; i<v.MyLength(); ++i)
-    v[i] = a_*v[i] + b_*v1[i] + c_*v2[i];
+  if (b_ == zero) {
+    ::pressio::ops::update(v, a, v2, c);
+  } else if (c_ == zero) {
+    ::pressio::ops::update(v, a, v1, b);
+  } else {
+    for (int i=0; i<v.MyLength(); ++i) {
+      if (a_ == zero) {
+        v[i] = b_*v1[i] + c_*v2[i];
+      } else {
+        v[i] = a_*v[i] + b_*v1[i] + c_*v2[i];
+      }
+    }
+  }
 }
 
 //----------------------------------------------------------------------
@@ -130,13 +152,27 @@ update(T & v,     const scalar_t &a,
   assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v2, 0));
   assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v3, 0));
 
+  const auto zero = ::pressio::utils::Constants<scalar_t>::zero();
   scalar_t a_{a};
   scalar_t b_{b};
   scalar_t c_{c};
   scalar_t d_{d};
 
-  for (int i=0; i<v.MyLength(); ++i)
-    v[i] = a_*v[i] + b_*v1[i] + c_*v2[i] + d_*v3[i];
+  if (b_ == zero) {
+    ::pressio::ops::update(v, a, v2, c, v3, d);
+  } else if (c_ == zero) {
+    ::pressio::ops::update(v, a, v1, b, v3, d);
+  } else if (d_ == zero) {
+    ::pressio::ops::update(v, a, v1, b, v2, c);
+  } else {
+    for (int i=0; i<v.MyLength(); ++i) {
+      if (a_ == zero) {
+        v[i] = b_*v1[i] + c_*v2[i] + d_*v3[i];
+      } else {
+        v[i] = a_*v[i] + b_*v1[i] + c_*v2[i] + d_*v3[i];
+      }
+    }
+  }
 }
 
 //----------------------------------------------------------------------
@@ -165,14 +201,30 @@ update(T & v,         const scalar_t &a,
   assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v3, 0));
   assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v4, 0));
 
+  const auto zero = ::pressio::utils::Constants<scalar_t>::zero();
   scalar_t a_{a};
   scalar_t b_{b};
   scalar_t c_{c};
   scalar_t d_{d};
   scalar_t e_{e};
 
-  for (int i=0; i<v.MyLength(); ++i)
-    v[i] = a_*v[i] + b_*v1[i] + c_*v2[i] + d_*v3[i] + e_*v4[i];
+  if (b_ == zero) {
+    ::pressio::ops::update(v, a, v2, c, v3, d, v4, e);
+  } else if (c_ == zero) {
+    ::pressio::ops::update(v, a, v1, b, v3, d, v4, e);
+  } else if (d_ == zero) {
+    ::pressio::ops::update(v, a, v1, b, v2, c, v4, e);
+  } else if (e_ == zero) {
+    ::pressio::ops::update(v, a, v1, b, v2, c, v3, d);
+  } else {
+    for (int i = 0; i < v.MyLength(); ++i) {
+      if (a_ == zero) {
+        v[i] = b_*v1[i] + c_*v2[i] + d_*v3[i] + e_*v4[i];
+      } else {
+        v[i] = a_*v[i] + b_*v1[i] + c_*v2[i] + d_*v3[i] + e_*v4[i];
+      }
+    }
+  }
 }
 
 }}//end namespace pressio::ops

--- a/include/pressio/ops/epetra/ops_rank1_update.hpp
+++ b/include/pressio/ops/epetra/ops_rank1_update.hpp
@@ -65,13 +65,16 @@ template<typename T, typename scalar_t>
    || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value)
   && std::is_convertible<scalar_t, typename ::pressio::Traits<T>::scalar_type>::value
   >
-update(T & v,        const scalar_t a, 
+update(T & v,        const scalar_t a,
        const T & v1, const scalar_t b)
 {
   assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v1, 0));
 
+  scalar_t a_{a};
+  scalar_t b_{b};
+
   for (int i=0; i<v.MyLength(); ++i)
-    v[i] = a*v[i] + b*v1[i];
+    v[i] = a_*v[i] + b_*v1[i];
 }
 
 //----------------------------------------------------------------------
@@ -95,8 +98,12 @@ update(T & v,     const scalar_t &a,
   assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v1, 0));
   assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v2, 0));
 
+  scalar_t a_{a};
+  scalar_t b_{b};
+  scalar_t c_{c};
+
   for (int i=0; i<v.MyLength(); ++i)
-    v[i] = a*v[i] + b*v1[i] + c*v2[i];
+    v[i] = a_*v[i] + b_*v1[i] + c_*v2[i];
 }
 
 //----------------------------------------------------------------------
@@ -123,8 +130,13 @@ update(T & v,     const scalar_t &a,
   assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v2, 0));
   assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v3, 0));
 
+  scalar_t a_{a};
+  scalar_t b_{b};
+  scalar_t c_{c};
+  scalar_t d_{d};
+
   for (int i=0; i<v.MyLength(); ++i)
-    v[i] = a*v[i] + b*v1[i] + c*v2[i] + d*v3[i];
+    v[i] = a_*v[i] + b_*v1[i] + c_*v2[i] + d_*v3[i];
 }
 
 //----------------------------------------------------------------------
@@ -153,8 +165,14 @@ update(T & v,         const scalar_t &a,
   assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v3, 0));
   assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v4, 0));
 
+  scalar_t a_{a};
+  scalar_t b_{b};
+  scalar_t c_{c};
+  scalar_t d_{d};
+  scalar_t e_{e};
+
   for (int i=0; i<v.MyLength(); ++i)
-    v[i] = a*v[i] + b*v1[i] + c*v2[i] + d*v3[i] + e*v4[i];
+    v[i] = a_*v[i] + b_*v1[i] + c_*v2[i] + d_*v3[i] + e_*v4[i];
 }
 
 }}//end namespace pressio::ops

--- a/include/pressio/ops/epetra/ops_rank1_update.hpp
+++ b/include/pressio/ops/epetra/ops_rank1_update.hpp
@@ -54,22 +54,28 @@ namespace pressio{ namespace ops{
 //----------------------------------------------------------------------
 // computing:  V = a * V + b * V1
 //----------------------------------------------------------------------
-template<typename T, typename scalar_t>
+template<typename T, typename T1,
+         typename a_Type, typename b_Type>
 ::pressio::mpl::enable_if_t<
   // rank-1 update common constraints
      ::pressio::Traits<T>::rank == 1
+  && ::pressio::Traits<T1>::rank == 1
   // TPL/container specific
   && ::pressio::is_vector_epetra<T>::value
+  && ::pressio::is_vector_epetra<T1>::value
   // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<T, T1>::value
   && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
    || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value)
-  && std::is_convertible<scalar_t, typename ::pressio::Traits<T>::scalar_type>::value
+  && std::is_convertible<a_Type, typename ::pressio::Traits<T>::scalar_type>::value
+  && std::is_convertible<b_Type, typename ::pressio::Traits<T>::scalar_type>::value
   >
-update(T & v,        const scalar_t a,
-       const T & v1, const scalar_t b)
+update(T & v,         const a_Type a,
+       const T1 & v1, const b_Type b)
 {
   assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v1, 0));
 
+  using scalar_t = typename ::pressio::Traits<T>::scalar_type;
   const auto zero = ::pressio::utils::Constants<scalar_t>::zero();
   scalar_t a_{a};
   scalar_t b_{b};
@@ -90,24 +96,35 @@ update(T & v,        const scalar_t a,
 //----------------------------------------------------------------------
 //  overloads for computing this: V = a * V + b * V1 + c * V2
 //----------------------------------------------------------------------
-template<typename T, typename scalar_t>
+template<
+  class T, class T1, class T2,
+  class a_Type, class b_Type, class c_Type
+  >
 ::pressio::mpl::enable_if_t<
   // rank-1 update common constraints
      ::pressio::Traits<T>::rank == 1
+  && ::pressio::Traits<T1>::rank == 1
+  && ::pressio::Traits<T2>::rank == 1
   // TPL/container specific
   && ::pressio::is_vector_epetra<T>::value
+  && ::pressio::is_vector_epetra<T1>::value
+  && ::pressio::is_vector_epetra<T2>::value
   // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<T, T1, T2>::value
   && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
    || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value)
-  && std::is_convertible<scalar_t, typename ::pressio::Traits<T>::scalar_type>::value
+  && std::is_convertible<a_Type, typename ::pressio::Traits<T>::scalar_type>::value
+  && std::is_convertible<b_Type, typename ::pressio::Traits<T>::scalar_type>::value
+  && std::is_convertible<c_Type, typename ::pressio::Traits<T>::scalar_type>::value
   >
-update(T & v,     const scalar_t &a,
-	  const T & v1, const scalar_t &b,
-	  const T & v2, const scalar_t &c)
+update(T & v,         const a_Type &a,
+       const T1 & v1, const b_Type &b,
+       const T2 & v2, const c_Type &c)
 {
   assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v1, 0));
   assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v2, 0));
 
+  using scalar_t = typename ::pressio::Traits<T>::scalar_type;
   const auto zero = ::pressio::utils::Constants<scalar_t>::zero();
   scalar_t a_{a};
   scalar_t b_{b};
@@ -132,26 +149,40 @@ update(T & v,     const scalar_t &a,
 //  overloads for computing:
 //	V = a * V + b * V1 + c * V2 + d * V3
 //----------------------------------------------------------------------
-template<typename T, typename scalar_t>
+template<
+  class T, class T1, class T2, class T3,
+  class a_Type, class b_Type, class c_Type, class d_Type
+  >
 ::pressio::mpl::enable_if_t<
   // rank-1 update common constraints
      ::pressio::Traits<T>::rank == 1
+  && ::pressio::Traits<T1>::rank == 1
+  && ::pressio::Traits<T2>::rank == 1
+  && ::pressio::Traits<T3>::rank == 1
   // TPL/container specific
   && ::pressio::is_vector_epetra<T>::value
+  && ::pressio::is_vector_epetra<T1>::value
+  && ::pressio::is_vector_epetra<T2>::value
+  && ::pressio::is_vector_epetra<T3>::value
   // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<T, T1, T2, T3>::value
   && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
    || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value)
-  && std::is_convertible<scalar_t, typename ::pressio::Traits<T>::scalar_type>::value
+  && std::is_convertible<a_Type, typename ::pressio::Traits<T>::scalar_type>::value
+  && std::is_convertible<b_Type, typename ::pressio::Traits<T>::scalar_type>::value
+  && std::is_convertible<c_Type, typename ::pressio::Traits<T>::scalar_type>::value
+  && std::is_convertible<d_Type, typename ::pressio::Traits<T>::scalar_type>::value
   >
-update(T & v,     const scalar_t &a,
-	  const T & v1, const scalar_t &b,
-	  const T & v2, const scalar_t &c,
-	  const T & v3, const scalar_t &d)
+update(T & v,         const a_Type &a,
+       const T1 & v1, const b_Type &b,
+       const T2 & v2, const c_Type &c,
+       const T3 & v3, const d_Type &d)
 {
   assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v1, 0));
   assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v2, 0));
   assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v3, 0));
 
+  using scalar_t = typename ::pressio::Traits<T>::scalar_type;
   const auto zero = ::pressio::utils::Constants<scalar_t>::zero();
   scalar_t a_{a};
   scalar_t b_{b};
@@ -179,28 +210,45 @@ update(T & v,     const scalar_t &a,
 //  overloads for computing:
 //	V = a * V + b * V1 + c * V2 + d * V3 + e * V4
 //----------------------------------------------------------------------
-template<typename T, typename scalar_t>
+template<
+  class T, class T1, class T2, class T3, class T4,
+  class a_Type, class b_Type, class c_Type, class d_Type, class e_Type
+  >
 ::pressio::mpl::enable_if_t<
   // rank-1 update common constraints
      ::pressio::Traits<T>::rank == 1
+  && ::pressio::Traits<T1>::rank == 1
+  && ::pressio::Traits<T2>::rank == 1
+  && ::pressio::Traits<T3>::rank == 1
+  && ::pressio::Traits<T4>::rank == 1
   // TPL/container specific
   && ::pressio::is_vector_epetra<T>::value
+  && ::pressio::is_vector_epetra<T1>::value
+  && ::pressio::is_vector_epetra<T2>::value
+  && ::pressio::is_vector_epetra<T3>::value
+  && ::pressio::is_vector_epetra<T4>::value
   // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<T, T1, T2, T3, T4>::value
   && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
    || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value)
-  && std::is_convertible<scalar_t, typename ::pressio::Traits<T>::scalar_type>::value
+  && std::is_convertible<a_Type, typename ::pressio::Traits<T>::scalar_type>::value
+  && std::is_convertible<b_Type, typename ::pressio::Traits<T>::scalar_type>::value
+  && std::is_convertible<c_Type, typename ::pressio::Traits<T>::scalar_type>::value
+  && std::is_convertible<d_Type, typename ::pressio::Traits<T>::scalar_type>::value
+  && std::is_convertible<e_Type, typename ::pressio::Traits<T>::scalar_type>::value
   >
-update(T & v,         const scalar_t &a,
-    	  const T & v1, const scalar_t &b,
-    	  const T & v2, const scalar_t &c,
-    	  const T & v3, const scalar_t &d,
-    	  const T & v4, const scalar_t &e)
+update(T & v,         const a_Type &a,
+       const T1 & v1, const b_Type &b,
+       const T2 & v2, const c_Type &c,
+       const T3 & v3, const d_Type &d,
+       const T4 & v4, const e_Type &e)
 {
   assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v1, 0));
   assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v2, 0));
   assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v3, 0));
   assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v4, 0));
 
+  using scalar_t = typename ::pressio::Traits<T>::scalar_type;
   const auto zero = ::pressio::utils::Constants<scalar_t>::zero();
   scalar_t a_{a};
   scalar_t b_{b};

--- a/include/pressio/ops/epetra/ops_rank1_update.hpp
+++ b/include/pressio/ops/epetra/ops_rank1_update.hpp
@@ -68,6 +68,8 @@ template<typename T, typename scalar_t>
 update(T & v,        const scalar_t a, 
        const T & v1, const scalar_t b)
 {
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v1, 0));
+
   for (int i=0; i<v.MyLength(); ++i)
     v[i] = a*v[i] + b*v1[i];
 }
@@ -90,6 +92,9 @@ update(T & v,     const scalar_t &a,
 	  const T & v1, const scalar_t &b,
 	  const T & v2, const scalar_t &c)
 {
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v1, 0));
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v2, 0));
+
   for (int i=0; i<v.MyLength(); ++i)
     v[i] = a*v[i] + b*v1[i] + c*v2[i];
 }
@@ -114,6 +119,10 @@ update(T & v,     const scalar_t &a,
 	  const T & v2, const scalar_t &c,
 	  const T & v3, const scalar_t &d)
 {
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v1, 0));
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v2, 0));
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v3, 0));
+
   for (int i=0; i<v.MyLength(); ++i)
     v[i] = a*v[i] + b*v1[i] + c*v2[i] + d*v3[i];
 }
@@ -139,6 +148,11 @@ update(T & v,         const scalar_t &a,
     	  const T & v3, const scalar_t &d,
     	  const T & v4, const scalar_t &e)
 {
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v1, 0));
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v2, 0));
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v3, 0));
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v4, 0));
+
   for (int i=0; i<v.MyLength(); ++i)
     v[i] = a*v[i] + b*v1[i] + c*v2[i] + d*v3[i] + e*v4[i];
 }

--- a/include/pressio/ops/epetra/ops_rank1_update.hpp
+++ b/include/pressio/ops/epetra/ops_rank1_update.hpp
@@ -56,7 +56,14 @@ namespace pressio{ namespace ops{
 //----------------------------------------------------------------------
 template<typename T, typename scalar_t>
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_vector_epetra<T>::value
+  // rank-1 update common constraints
+     ::pressio::Traits<T>::rank == 1
+  // TPL/container specific
+  && ::pressio::is_vector_epetra<T>::value
+  // scalar compatibility
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value)
+  && std::is_convertible<scalar_t, typename ::pressio::Traits<T>::scalar_type>::value
   >
 update(T & v,        const scalar_t a, 
        const T & v1, const scalar_t b)
@@ -70,7 +77,14 @@ update(T & v,        const scalar_t a,
 //----------------------------------------------------------------------
 template<typename T, typename scalar_t>
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_vector_epetra<T>::value
+  // rank-1 update common constraints
+     ::pressio::Traits<T>::rank == 1
+  // TPL/container specific
+  && ::pressio::is_vector_epetra<T>::value
+  // scalar compatibility
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value)
+  && std::is_convertible<scalar_t, typename ::pressio::Traits<T>::scalar_type>::value
   >
 update(T & v,     const scalar_t &a,
 	  const T & v1, const scalar_t &b,
@@ -86,7 +100,14 @@ update(T & v,     const scalar_t &a,
 //----------------------------------------------------------------------
 template<typename T, typename scalar_t>
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_vector_epetra<T>::value
+  // rank-1 update common constraints
+     ::pressio::Traits<T>::rank == 1
+  // TPL/container specific
+  && ::pressio::is_vector_epetra<T>::value
+  // scalar compatibility
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value)
+  && std::is_convertible<scalar_t, typename ::pressio::Traits<T>::scalar_type>::value
   >
 update(T & v,     const scalar_t &a,
 	  const T & v1, const scalar_t &b,
@@ -103,7 +124,14 @@ update(T & v,     const scalar_t &a,
 //----------------------------------------------------------------------
 template<typename T, typename scalar_t>
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_vector_epetra<T>::value
+  // rank-1 update common constraints
+     ::pressio::Traits<T>::rank == 1
+  // TPL/container specific
+  && ::pressio::is_vector_epetra<T>::value
+  // scalar compatibility
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value)
+  && std::is_convertible<scalar_t, typename ::pressio::Traits<T>::scalar_type>::value
   >
 update(T & v,         const scalar_t &a,
     	  const T & v1, const scalar_t &b,

--- a/include/pressio/ops/epetra/ops_rank1_update.hpp
+++ b/include/pressio/ops/epetra/ops_rank1_update.hpp
@@ -81,14 +81,19 @@ update(T & v,         const a_Type a,
   scalar_t b_{b};
 
   if (b_ == zero) {
-    ::pressio::ops::scale(v, a_);
-  } else {
-    for (int i=0; i<v.MyLength(); ++i) {
-      if (a_ == zero) {
-        v[i] = b_*v1[i];
-      } else {
-        v[i] = a_*v[i] + b_*v1[i];
-      }
+    if (a_ == zero) {
+      ::pressio::ops::set_zero(v);
+    } else {
+      ::pressio::ops::scale(v, a_);
+    }
+    return;
+  }
+
+  for (int i=0; i<v.MyLength(); ++i) {
+    if (a_ == zero) {
+      v[i] = b_*v1[i];
+    } else {
+      v[i] = a_*v[i] + b_*v1[i];
     }
   }
 }

--- a/tests/functional_small/ops/ops_epetra_vector.cc
+++ b/tests/functional_small/ops/ops_epetra_vector.cc
@@ -2,7 +2,10 @@
 #include "epetra_only_fixtures.hpp"
 #include "pressio/ops.hpp"
 
-TEST_F(epetraVectorGlobSize15Fixture, vector_clone)
+// convenient alias for nice test names
+using ops_epetra = epetraVectorGlobSize15Fixture;
+
+TEST_F(ops_epetra, vector_clone)
 {
     auto a = pressio::ops::clone(*myVector_);
     ASSERT_TRUE(a.Values() != myVector_->Values());
@@ -17,12 +20,12 @@ TEST_F(epetraVectorGlobSize15Fixture, vector_clone)
     }
 }
 
-TEST_F(epetraVectorGlobSize15Fixture, vector_extent)
+TEST_F(ops_epetra, vector_extent)
 {
     ASSERT_TRUE(pressio::ops::extent(*myVector_,0) == numProc_ * 5.);
 }
 
-TEST_F(epetraVectorGlobSize15Fixture, vector_deep_copy)
+TEST_F(ops_epetra, vector_deep_copy)
 {
     myVector_->PutScalar(-5.);
     auto a = pressio::ops::clone(*myVector_);
@@ -33,7 +36,7 @@ TEST_F(epetraVectorGlobSize15Fixture, vector_deep_copy)
     }
 }
 
-TEST_F(epetraVectorGlobSize15Fixture, vector_setzero)
+TEST_F(ops_epetra, vector_setzero)
 {
     myVector_->PutScalar(23.);
     for (int i=0; i<localSize_; ++i){
@@ -46,7 +49,7 @@ TEST_F(epetraVectorGlobSize15Fixture, vector_setzero)
     }
 }
 
-TEST_F(epetraVectorGlobSize15Fixture, vector_fill)
+TEST_F(ops_epetra, vector_fill)
 {
     pressio::ops::fill(*myVector_, 55.);
     auto & x_h = *myVector_;
@@ -55,7 +58,7 @@ TEST_F(epetraVectorGlobSize15Fixture, vector_fill)
     }
 }
 
-TEST_F(epetraVectorGlobSize15Fixture, vector_abs)
+TEST_F(ops_epetra, vector_abs)
 {
     pressio::ops::fill(*myVector_, -5.);
     auto & x_h = *myVector_;
@@ -71,7 +74,7 @@ TEST_F(epetraVectorGlobSize15Fixture, vector_abs)
     }
 }
 
-TEST_F(epetraVectorGlobSize15Fixture, vector_dot)
+TEST_F(ops_epetra, vector_dot)
 {
   auto a = pressio::ops::clone(*myVector_);
   auto b = pressio::ops::clone(*myVector_);
@@ -86,21 +89,21 @@ TEST_F(epetraVectorGlobSize15Fixture, vector_dot)
   EXPECT_DOUBLE_EQ(res, numProc_ * 5.);
 }
 
-TEST_F(epetraVectorGlobSize15Fixture, vector_norm2)
+TEST_F(ops_epetra, vector_norm2)
 {
   myVector_->PutScalar(1.0);
   auto mynorm = pressio::ops::norm2(*myVector_);
   EXPECT_NEAR(mynorm, std::sqrt(numProc_ * 5.0), 1e-15);
 }
 
-TEST_F(epetraVectorGlobSize15Fixture, vector_norm1)
+TEST_F(ops_epetra, vector_norm1)
 {
   myVector_->PutScalar(1.0);
   auto mynorm = pressio::ops::norm1(*myVector_);
   EXPECT_DOUBLE_EQ(mynorm, numProc_ * 5.0);
 }
 
-TEST_F(epetraVectorGlobSize15Fixture, vector_pow)
+TEST_F(ops_epetra, vector_pow)
 {
   auto & x = *myVector_;
   x.PutScalar(2.);
@@ -110,7 +113,7 @@ TEST_F(epetraVectorGlobSize15Fixture, vector_pow)
   }
 }
 
-TEST_F(epetraVectorGlobSize15Fixture, vector_absPowPos)
+TEST_F(ops_epetra, vector_absPowPos)
 {
   auto & x = *myVector_;
   x.PutScalar(-2.);
@@ -171,7 +174,7 @@ TEST_F(epetraVectorGlobSize15Fixture, vector_absPowPos)
 //   }
 // }
 
-TEST_F(epetraVectorGlobSize15Fixture, vector_update1_a)
+TEST_F(ops_epetra, vector_update1_a)
 {
     auto v = pressio::ops::clone(*myVector_);
     pressio::ops::fill(v, 1.);
@@ -183,7 +186,7 @@ TEST_F(epetraVectorGlobSize15Fixture, vector_update1_a)
     }
 }
 
-TEST_F(epetraVectorGlobSize15Fixture, vector_update1_b)
+TEST_F(ops_epetra, vector_update1_b)
 {
     auto v = pressio::ops::clone(*myVector_);
     pressio::ops::fill(v, 1.);
@@ -195,7 +198,7 @@ TEST_F(epetraVectorGlobSize15Fixture, vector_update1_b)
     }
 }
 
-TEST_F(epetraVectorGlobSize15Fixture, vector_update2_a)
+TEST_F(ops_epetra, vector_update2_a)
 {
     auto v = pressio::ops::clone(*myVector_);
     pressio::ops::fill(v, 1.);
@@ -210,7 +213,7 @@ TEST_F(epetraVectorGlobSize15Fixture, vector_update2_a)
     }
 }
 
-TEST_F(epetraVectorGlobSize15Fixture, vector_update2_b)
+TEST_F(ops_epetra, vector_update2_b)
 {
     auto v = pressio::ops::clone(*myVector_);
     pressio::ops::fill(v, 1.);
@@ -225,7 +228,7 @@ TEST_F(epetraVectorGlobSize15Fixture, vector_update2_b)
     }
 }
 
-TEST_F(epetraVectorGlobSize15Fixture, vector_update3_a)
+TEST_F(ops_epetra, vector_update3_a)
 {
     auto v = pressio::ops::clone(*myVector_);
     pressio::ops::fill(v, 1.);
@@ -242,7 +245,7 @@ TEST_F(epetraVectorGlobSize15Fixture, vector_update3_a)
     }
 }
 
-TEST_F(epetraVectorGlobSize15Fixture, vector_update3_b)
+TEST_F(ops_epetra, vector_update3_b)
 {
     auto v = pressio::ops::clone(*myVector_);
     pressio::ops::fill(v, 1.);
@@ -259,7 +262,7 @@ TEST_F(epetraVectorGlobSize15Fixture, vector_update3_b)
     }
 }
 
-TEST_F(epetraVectorGlobSize15Fixture, vector_update4_a)
+TEST_F(ops_epetra, vector_update4_a)
 {
     auto v = pressio::ops::clone(*myVector_);
     pressio::ops::fill(v, 1.);
@@ -278,7 +281,7 @@ TEST_F(epetraVectorGlobSize15Fixture, vector_update4_a)
     }
 }
 
-TEST_F(epetraVectorGlobSize15Fixture, vector_update4_b)
+TEST_F(ops_epetra, vector_update4_b)
 {
     auto v = pressio::ops::clone(*myVector_);
     pressio::ops::fill(v, 1.);
@@ -297,7 +300,7 @@ TEST_F(epetraVectorGlobSize15Fixture, vector_update4_b)
     }
 }
 
-TEST_F(epetraVectorGlobSize15Fixture, vector_update4_c)
+TEST_F(ops_epetra, vector_update4_c)
 {
     auto v = pressio::ops::clone(*myVector_);
     pressio::ops::fill(v, 3.);
@@ -310,7 +313,7 @@ TEST_F(epetraVectorGlobSize15Fixture, vector_update4_c)
     }
 }
 
-TEST_F(epetraVectorGlobSize15Fixture, vector_update_nan)
+TEST_F(ops_epetra, vector_update_nan)
 {
     const auto nan = std::nan("0");
     auto v = pressio::ops::clone(*myVector_);
@@ -342,7 +345,7 @@ TEST_F(epetraVectorGlobSize15Fixture, vector_update_nan)
     }
 }
 
-TEST_F(epetraVectorGlobSize15Fixture, vector_elementwiseMultiply)
+TEST_F(ops_epetra, vector_elementwiseMultiply)
 {
     auto y = pressio::ops::clone(*myVector_);
     pressio::ops::fill(y, 1.);

--- a/tests/functional_small/ops/ops_epetra_vector.cc
+++ b/tests/functional_small/ops/ops_epetra_vector.cc
@@ -19,7 +19,7 @@ TEST_F(epetraVectorGlobSize15Fixture, vector_clone)
 
 TEST_F(epetraVectorGlobSize15Fixture, vector_extent)
 {
-    ASSERT_TRUE(pressio::ops::extent(*myVector_,0) == 15);
+    ASSERT_TRUE(pressio::ops::extent(*myVector_,0) == numProc_ * 5.);
 }
 
 TEST_F(epetraVectorGlobSize15Fixture, vector_deep_copy)
@@ -79,25 +79,25 @@ TEST_F(epetraVectorGlobSize15Fixture, vector_dot)
   b.PutScalar(1.0);
 
   auto res = ::pressio::ops::dot(a, b);
-  EXPECT_DOUBLE_EQ(res, 15.0);
+  EXPECT_DOUBLE_EQ(res, numProc_ * 5.);
 
   res = 0.0;
   ::pressio::ops::dot(a, b, res);
-  EXPECT_DOUBLE_EQ(res, 15.0);
+  EXPECT_DOUBLE_EQ(res, numProc_ * 5.);
 }
 
 TEST_F(epetraVectorGlobSize15Fixture, vector_norm2)
 {
   myVector_->PutScalar(1.0);
   auto mynorm = pressio::ops::norm2(*myVector_);
-  EXPECT_NEAR(mynorm, std::sqrt(15.0), 1e-15);
+  EXPECT_NEAR(mynorm, std::sqrt(numProc_ * 5.0), 1e-15);
 }
 
 TEST_F(epetraVectorGlobSize15Fixture, vector_norm1)
 {
   myVector_->PutScalar(1.0);
   auto mynorm = pressio::ops::norm1(*myVector_);
-  EXPECT_DOUBLE_EQ(mynorm, 15.0);
+  EXPECT_DOUBLE_EQ(mynorm, numProc_ * 5.0);
 }
 
 TEST_F(epetraVectorGlobSize15Fixture, vector_pow)

--- a/tests/functional_small/ops/ops_epetra_vector.cc
+++ b/tests/functional_small/ops/ops_epetra_vector.cc
@@ -297,6 +297,51 @@ TEST_F(epetraVectorGlobSize15Fixture, vector_update4_b)
     }
 }
 
+TEST_F(epetraVectorGlobSize15Fixture, vector_update4_c)
+{
+    auto v = pressio::ops::clone(*myVector_);
+    pressio::ops::fill(v, 3.);
+    auto a = pressio::ops::clone(*myVector_);
+    pressio::ops::fill(a, std::nan("0"));
+
+    pressio::ops::update(v, 2., a, 0., a, 0., a, 0., a, 0.);
+    for (int i=0; i<localSize_; ++i){
+      EXPECT_DOUBLE_EQ(v[i], 6.);
+    }
+}
+
+TEST_F(epetraVectorGlobSize15Fixture, vector_update_nan)
+{
+    const auto nan = std::nan("0");
+    auto v = pressio::ops::clone(*myVector_);
+    auto a = pressio::ops::clone(*myVector_);
+    pressio::ops::fill(a, 2);
+
+    pressio::ops::fill(v, nan);
+    pressio::ops::update(v, 0., a, 1.);
+    for (int i=0; i<localSize_; ++i){
+      EXPECT_DOUBLE_EQ(v[i], 2.);
+    }
+
+    pressio::ops::fill(v, nan);
+    pressio::ops::update(v, 0., a, 1., a, 2.);
+    for (int i=0; i<localSize_; ++i){
+      EXPECT_DOUBLE_EQ(v[i], 6.);
+    }
+
+    pressio::ops::fill(v, nan);
+    pressio::ops::update(v, 0., a, 1., a, 2., a, 3.);
+    for (int i=0; i<localSize_; ++i){
+      EXPECT_DOUBLE_EQ(v[i], 12.);
+    }
+
+    pressio::ops::fill(v, nan);
+    pressio::ops::update(v, 0., a, 1., a, 2., a, 3., a, 4.);
+    for (int i=0; i<localSize_; ++i){
+      EXPECT_DOUBLE_EQ(v[i], 20.);
+    }
+}
+
 TEST_F(epetraVectorGlobSize15Fixture, vector_elementwiseMultiply)
 {
     auto y = pressio::ops::clone(*myVector_);

--- a/tests/functional_small/ops/ops_epetra_vector.cc
+++ b/tests/functional_small/ops/ops_epetra_vector.cc
@@ -319,34 +319,34 @@ TEST_F(ops_epetra, vector_update_nan)
     pressio::ops::fill(v, 1.);
     auto a = pressio::ops::clone(*myVector_);
     pressio::ops::fill(a, 1.);
-    auto nan = pressio::ops::clone(*myVector_);
-    pressio::ops::fill(nan, std::nan("0"));
+    auto vecOfNans = pressio::ops::clone(*myVector_);
+    pressio::ops::fill(vecOfNans, std::nan("0"));
 
     // Note: this test covers just enough nan/non-nan combinations
     // to trigger and verify all execution paths in our update()
     // implementations, which include anti-NaN-injection variants
-    pressio::ops::update(v, 1., nan, 0.);
+    pressio::ops::update(v, 1., vecOfNans, 0.);
     EXPECT_DOUBLE_EQ(v[0], 1.0);
 
-    pressio::ops::update(v, 1., nan, 0., nan, 0.);
+    pressio::ops::update(v, 1., vecOfNans, 0., vecOfNans, 0.);
     EXPECT_DOUBLE_EQ(v[0], 1.0);
-    pressio::ops::update(v, 1., a, 1., nan, 0.);
+    pressio::ops::update(v, 1., a, 1., vecOfNans, 0.);
     EXPECT_DOUBLE_EQ(v[0], 2.);
 
-    pressio::ops::update(v, 1., nan, 0., nan, 0., nan, 0.);
+    pressio::ops::update(v, 1., vecOfNans, 0., vecOfNans, 0., vecOfNans, 0.);
     EXPECT_DOUBLE_EQ(v[0], 2.0);
-    pressio::ops::update(v, 1., a, 1., nan, 0., a, 1.);
+    pressio::ops::update(v, 1., a, 1., vecOfNans, 0., a, 1.);
     EXPECT_DOUBLE_EQ(v[0], 4.);
-    pressio::ops::update(v, 1., a, 1., a, 1., nan, 0.);
+    pressio::ops::update(v, 1., a, 1., a, 1., vecOfNans, 0.);
     EXPECT_DOUBLE_EQ(v[0], 6.);
 
-    pressio::ops::update(v, 1., nan, 0., nan, 0., nan, 0., nan, 0.);
+    pressio::ops::update(v, 1., vecOfNans, 0., vecOfNans, 0., vecOfNans, 0., vecOfNans, 0.);
     EXPECT_DOUBLE_EQ(v[0], 6.0);
-    pressio::ops::update(v, 1., a, 1., nan, 0., a, 1., a, 1.);
+    pressio::ops::update(v, 1., a, 1., vecOfNans, 0., a, 1., a, 1.);
     EXPECT_DOUBLE_EQ(v[0], 9.);
-    pressio::ops::update(v, 1., a, 1., a, 1., nan, 0., a, 1.);
+    pressio::ops::update(v, 1., a, 1., a, 1., vecOfNans, 0., a, 1.);
     EXPECT_DOUBLE_EQ(v[0], 12.);
-    pressio::ops::update(v, 1., a, 1., a, 1., a, 1., nan, 0.);
+    pressio::ops::update(v, 1., a, 1., a, 1., a, 1., vecOfNans, 0.);
     EXPECT_DOUBLE_EQ(v[0], 15.);
 }
 


### PR DESCRIPTION
Contents:
- [x] revised overload constraints 
- [x] added extent check
- [x] added explicit type casting for coefficients
- [x] fixed NaN injection through zero coefficients and added relevant unit test

refs #448