### PR TITLE
ops: eigen: cover all NaN execution paths of rank-1 update in unit tests

### DIFF
--- a/tests/functional_small/ops/ops_eigen_vector.cc
+++ b/tests/functional_small/ops/ops_eigen_vector.cc
@@ -281,36 +281,36 @@ TEST(ops_eigen, vector_update4)
 
 TEST(ops_eigen, vector_update_nan1)
 {
-  V_t v, a, nan;
+  V_t v, a, vecOfNans;
   pressio::ops::fill(v, 1.);
   pressio::ops::fill(a, 1.);
-  pressio::ops::fill(nan, std::nan("0"));
+  pressio::ops::fill(vecOfNans, std::nan("0"));
 
   // Note: this test covers just enough nan/non-nan combinations
   // to trigger and verify all execution paths in our update()
   // implementations, which include anti-NaN-injection variants
-  pressio::ops::update(v, 1., nan, 0.);
+  pressio::ops::update(v, 1., vecOfNans, 0.);
   EXPECT_DOUBLE_EQ(v(0), 1.0);
 
-  pressio::ops::update(v, 1., nan, 0., nan, 0.);
+  pressio::ops::update(v, 1., vecOfNans, 0., vecOfNans, 0.);
   EXPECT_DOUBLE_EQ(v(0), 1.0);
-  pressio::ops::update(v, 1., a, 1., nan, 0.);
+  pressio::ops::update(v, 1., a, 1., vecOfNans, 0.);
   EXPECT_DOUBLE_EQ(v(0), 2.);
 
-  pressio::ops::update(v, 1., nan, 0., nan, 0., nan, 0.);
+  pressio::ops::update(v, 1., vecOfNans, 0., vecOfNans, 0., vecOfNans, 0.);
   EXPECT_DOUBLE_EQ(v(0), 2.0);
-  pressio::ops::update(v, 1., a, 1., nan, 0., a, 1.);
+  pressio::ops::update(v, 1., a, 1., vecOfNans, 0., a, 1.);
   EXPECT_DOUBLE_EQ(v(0), 4.);
-  pressio::ops::update(v, 1., a, 1., a, 1., nan, 0.);
+  pressio::ops::update(v, 1., a, 1., a, 1., vecOfNans, 0.);
   EXPECT_DOUBLE_EQ(v(0), 6.);
 
-  pressio::ops::update(v, 1., nan, 0., nan, 0., nan, 0., nan, 0.);
+  pressio::ops::update(v, 1., vecOfNans, 0., vecOfNans, 0., vecOfNans, 0., vecOfNans, 0.);
   EXPECT_DOUBLE_EQ(v(0), 6.0);
-  pressio::ops::update(v, 1., a, 1., nan, 0., a, 1., a, 1.);
+  pressio::ops::update(v, 1., a, 1., vecOfNans, 0., a, 1., a, 1.);
   EXPECT_DOUBLE_EQ(v(0), 9.);
-  pressio::ops::update(v, 1., a, 1., a, 1., nan, 0., a, 1.);
+  pressio::ops::update(v, 1., a, 1., a, 1., vecOfNans, 0., a, 1.);
   EXPECT_DOUBLE_EQ(v(0), 12.);
-  pressio::ops::update(v, 1., a, 1., a, 1., a, 1., nan, 0.);
+  pressio::ops::update(v, 1., a, 1., a, 1., a, 1., vecOfNans, 0.);
   EXPECT_DOUBLE_EQ(v(0), 15.);
 }
 

--- a/tests/functional_small/ops/ops_eigen_vector.cc
+++ b/tests/functional_small/ops/ops_eigen_vector.cc
@@ -3,6 +3,7 @@
 #include "pressio/ops.hpp"
 
 using T = Eigen::VectorXd;
+using V_t = Eigen::Matrix<double,3,1>;
 
 TEST(ops_eigen, vector_clone)
 {
@@ -210,7 +211,6 @@ TEST(ops_eigen, vector_absPowNeg)
 
 TEST(ops_eigen, vector_update1)
 {
-  using V_t = Eigen::Matrix<double,3,1>;
   V_t v; v << 1.,2.,3.;
   V_t a; a << 1.,2.,3.;
 
@@ -227,7 +227,6 @@ TEST(ops_eigen, vector_update1)
 
 TEST(ops_eigen, vector_update2)
 {
-  using V_t = Eigen::Matrix<double,3,1>;
   V_t v; v << 1.,2.,3.;
   V_t a; a << 1.,2.,3.;
   V_t b; b << 1.,2.,3.;
@@ -245,7 +244,6 @@ TEST(ops_eigen, vector_update2)
 
 TEST(ops_eigen, vector_update3)
 {
-  using V_t = Eigen::Matrix<double,3,1>;
   V_t v; v << 1.,2.,3.;
   V_t a; a << 1.,2.,3.;
   V_t b; b << 1.,2.,3.;
@@ -264,7 +262,6 @@ TEST(ops_eigen, vector_update3)
 
 TEST(ops_eigen, vector_update4)
 {
-  using V_t = Eigen::Matrix<double,3,1>;
   V_t v; v << 1.,2.,3.;
   V_t a; a << 1.,2.,3.;
   V_t b; b << 1.,2.,3.;
@@ -284,73 +281,69 @@ TEST(ops_eigen, vector_update4)
 
 TEST(ops_eigen, vector_update_nan1)
 {
-  const auto nan = std::nan("0");
-  using V_t = Eigen::Matrix<double,3,1>;
-  V_t v; v << 1.,2.,3.;
-  V_t a; a << nan,nan,nan;
-  V_t b; b << nan,nan,nan;
-  V_t c; c << nan,nan,nan;
-  V_t d; d << nan,nan,nan;
+  V_t v, a, nan;
+  pressio::ops::fill(v, 1.);
+  pressio::ops::fill(a, 1.);
+  pressio::ops::fill(nan, std::nan("0"));
 
-  pressio::ops::update(v, 1., a, 0.);
-  EXPECT_DOUBLE_EQ( v(0), 1.0);
-  EXPECT_DOUBLE_EQ( v(1), 2.0);
-  EXPECT_DOUBLE_EQ( v(2), 3.0);
+  // Note: this test covers just enough nan/non-nan combinations
+  // to trigger and verify all execution paths in our update()
+  // implementations, which include anti-NaN-injection variants
+  pressio::ops::update(v, 1., nan, 0.);
+  EXPECT_DOUBLE_EQ(v(0), 1.0);
 
-  pressio::ops::update(v, 1., a, 0., b, 0.);
-  EXPECT_DOUBLE_EQ( v(0), 1.0);
-  EXPECT_DOUBLE_EQ( v(1), 2.0);
-  EXPECT_DOUBLE_EQ( v(2), 3.0);
+  pressio::ops::update(v, 1., nan, 0., nan, 0.);
+  EXPECT_DOUBLE_EQ(v(0), 1.0);
+  pressio::ops::update(v, 1., a, 1., nan, 0.);
+  EXPECT_DOUBLE_EQ(v(0), 2.);
 
-  pressio::ops::update(v, 1., a, 0., b, 0., c, 0.);
-  EXPECT_DOUBLE_EQ( v(0), 1.0);
-  EXPECT_DOUBLE_EQ( v(1), 2.0);
-  EXPECT_DOUBLE_EQ( v(2), 3.0);
+  pressio::ops::update(v, 1., nan, 0., nan, 0., nan, 0.);
+  EXPECT_DOUBLE_EQ(v(0), 2.0);
+  pressio::ops::update(v, 1., a, 1., nan, 0., a, 1.);
+  EXPECT_DOUBLE_EQ(v(0), 4.);
+  pressio::ops::update(v, 1., a, 1., a, 1., nan, 0.);
+  EXPECT_DOUBLE_EQ(v(0), 6.);
 
-  pressio::ops::update(v, 1., a, 0., b, 0., c, 0., d, 0.);
-  EXPECT_DOUBLE_EQ( v(0), 1.0);
-  EXPECT_DOUBLE_EQ( v(1), 2.0);
-  EXPECT_DOUBLE_EQ( v(2), 3.0);
+  pressio::ops::update(v, 1., nan, 0., nan, 0., nan, 0., nan, 0.);
+  EXPECT_DOUBLE_EQ(v(0), 6.0);
+  pressio::ops::update(v, 1., a, 1., nan, 0., a, 1., a, 1.);
+  EXPECT_DOUBLE_EQ(v(0), 9.);
+  pressio::ops::update(v, 1., a, 1., a, 1., nan, 0., a, 1.);
+  EXPECT_DOUBLE_EQ(v(0), 12.);
+  pressio::ops::update(v, 1., a, 1., a, 1., a, 1., nan, 0.);
+  EXPECT_DOUBLE_EQ(v(0), 15.);
 }
 
+// injects NaN through the updated vector
 TEST(ops_eigen, vector_update_nan2)
 {
   const auto nan = std::nan("0");
-  using V_t = Eigen::Matrix<double,3,1>;
-  V_t v;
-  V_t a; a << 1,2,3;
-  V_t b; b << 4,5,6;
-  V_t c; c << 7,8,9;
-  V_t d; d << 3,5,8;
+  V_t v, a;
+  pressio::ops::fill(a, 1.);
 
-  v << nan,nan,nan;
+  pressio::ops::fill(v, nan);
   pressio::ops::update(v, 0., a, 1.);
-  EXPECT_DOUBLE_EQ( v(0), 1.0);
-  EXPECT_DOUBLE_EQ( v(1), 2.0);
-  EXPECT_DOUBLE_EQ( v(2), 3.0);
+  EXPECT_DOUBLE_EQ(v(0), 1.0);
 
-  v << nan,nan,nan;
-  pressio::ops::update(v, 0., a, 1., b, 1.);
-  EXPECT_DOUBLE_EQ( v(0), 5.0);
-  EXPECT_DOUBLE_EQ( v(1), 7.0);
-  EXPECT_DOUBLE_EQ( v(2), 9.0);
+  pressio::ops::fill(v, nan);
+  pressio::ops::update(v, 0., a, 0.);
+  EXPECT_DOUBLE_EQ(v(0), 0.0);
 
-  v << nan,nan,nan;
-  pressio::ops::update(v, 0., a, 1., b, 1., c, 1.);
-  EXPECT_DOUBLE_EQ( v(0), 12.0);
-  EXPECT_DOUBLE_EQ( v(1), 15.0);
-  EXPECT_DOUBLE_EQ( v(2), 18.0);
+  pressio::ops::fill(v, nan);
+  pressio::ops::update(v, 0., a, 1., a, 1.);
+  EXPECT_DOUBLE_EQ(v(0), 2.0);
 
-  v << nan,nan,nan;
-  pressio::ops::update(v, 0., a, 1., b, 1., c, 1., d, 1.);
-  EXPECT_DOUBLE_EQ( v(0), 15.0);
-  EXPECT_DOUBLE_EQ( v(1), 20.0);
-  EXPECT_DOUBLE_EQ( v(2), 26.0);
+  pressio::ops::fill(v, nan);
+  pressio::ops::update(v, 0., a, 1., a, 1., a, 1.);
+  EXPECT_DOUBLE_EQ(v(0), 3.0);
+
+  pressio::ops::fill(v, nan);
+  pressio::ops::update(v, 0., a, 1., a, 1., a, 1., a, 1.);
+  EXPECT_DOUBLE_EQ(v(0), 4.0);
 }
 
 TEST(ops_eigen, vector_elementwiseMultiply)
 {
-  using V_t = Eigen::Matrix<double,3,1>;
   V_t y; y << 1.,2.,3.;
   V_t x; x << 2.,3.,4.;
   V_t z; z << 3.,4.,5.;

--- a/tests/functional_small/ops/ops_eigen_vector.cc
+++ b/tests/functional_small/ops/ops_eigen_vector.cc
@@ -342,6 +342,48 @@ TEST(ops_eigen, vector_update_nan2)
   EXPECT_DOUBLE_EQ(v(0), 4.0);
 }
 
+TEST(ops_kokkos, vector_update_expr_span)
+{
+  T v0(5);
+  T a0(5);
+  auto v = pressio::span(v0, 1, 3);
+  auto a = pressio::span(a0, 1, 3);
+  pressio::ops::fill(v, 10.);
+  pressio::ops::fill(a, 1.);
+
+  pressio::ops::update(v, 1., a, 1.);
+  pressio::ops::update(v, 1., a, 1., a, 2.);
+  pressio::ops::update(v, 1., a, 1., a, 2., a, 3.);
+  pressio::ops::update(v, 1., a, 1., a, 2., a, 3., a, 4.);
+
+  // Note: just check the final result as this test is more about
+  //       whether expressions compile and work than computation itself
+  EXPECT_DOUBLE_EQ(v(0), 30.0);
+  EXPECT_DOUBLE_EQ(v(1), 30.0);
+  EXPECT_DOUBLE_EQ(v(2), 30.0);
+}
+
+TEST(ops_kokkos, vector_update_expr_diag)
+{
+  Eigen::Matrix<double, 3, 3> v0;
+  Eigen::Matrix<double, 3, 3> a0;
+  auto v = pressio::diag(v0);
+  auto a = pressio::diag(a0);
+  pressio::ops::fill(v, 10.);
+  pressio::ops::fill(a, 1.);
+
+  pressio::ops::update(v, 1., a, 1.);
+  pressio::ops::update(v, 1., a, 1., a, 2.);
+  pressio::ops::update(v, 1., a, 1., a, 2., a, 3.);
+  pressio::ops::update(v, 1., a, 1., a, 2., a, 3., a, 4.);
+
+  // Note: just check the final result as this test is more about
+  //       whether expressions compile and work than computation itself
+  EXPECT_DOUBLE_EQ(v(0), 30.0);
+  EXPECT_DOUBLE_EQ(v(1), 30.0);
+  EXPECT_DOUBLE_EQ(v(2), 30.0);
+}
+
 TEST(ops_eigen, vector_elementwiseMultiply)
 {
   V_t y; y << 1.,2.,3.;


### PR DESCRIPTION
follows #536 