### PR TITLE
 ops: kokkos: revise rank-1 update

### DIFF
--- a/include/pressio/ops/kokkos/ops_vector_update.hpp
+++ b/include/pressio/ops/kokkos/ops_vector_update.hpp
@@ -95,6 +95,8 @@ template<
 update(T & v, const a_Type &a,
     const T1 & v1, const b_Type &b)
 {
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v1, 0));
+
   using scalar_t = typename ::pressio::Traits<T>::scalar_type;
   static_assert(impl::_kokkosUpdateAdmissibleOperands<scalar_t,T,T1>::value,"");
   ::KokkosBlas::axpby(b, impl::get_native(v1), a, impl::get_native(v));
@@ -121,6 +123,8 @@ template<typename T, typename T1, typename T2, typename b_Type>
   >
 update(T & v, const T1 & v1, const b_Type &b)
 {
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v1, 0));
+
   using scalar_t = typename ::pressio::Traits<T>::scalar_type;
   static_assert(impl::_kokkosUpdateAdmissibleOperands<scalar_t, T1,T2>::value,"");
   constexpr auto zero = ::pressio::utils::Constants<scalar_t>::zero();
@@ -158,6 +162,9 @@ update(T & v, const a_Type &a,
     const T1 & v1, const b_Type &b,
     const T2 & v2, const c_Type &c)
 {
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v1, 0));
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v2, 0));
+
   using scalar_t = typename ::pressio::Traits<T>::scalar_type;
   static_assert(impl::_kokkosUpdateAdmissibleOperands<scalar_t,T,T1,T2>::value,"");
 
@@ -199,6 +206,9 @@ update(T & v,
     const T1 & v1, const b_Type &b,
     const T2 & v2, const c_Type &c)
 {
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v1, 0));
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v2, 0));
+
   using scalar_t = typename ::pressio::Traits<T>::scalar_type;
   static_assert(impl::_kokkosUpdateAdmissibleOperands<scalar_t,T,T1,T2>::value,"");
 
@@ -250,6 +260,10 @@ update(T & v, const a_Type &a,
     const T2 & v2, const c_Type &c,
     const T3 & v3, const d_Type &d)
 {
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v1, 0));
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v2, 0));
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v3, 0));
+
   using scalar_t = typename ::pressio::Traits<T>::scalar_type;
   static_assert(impl::_kokkosUpdateAdmissibleOperands<scalar_t,T,T1,T2,T3>::value,"");
 
@@ -299,6 +313,10 @@ update(T & v,
     const T2 & v2, const c_Type &c,
     const T3 & v3, const d_Type &d)
 {
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v1, 0));
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v2, 0));
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v3, 0));
+
   using scalar_t = typename ::pressio::Traits<T>::scalar_type;
   static_assert(impl::_kokkosUpdateAdmissibleOperands<scalar_t,T,T1,T2,T3>::value,"");
 
@@ -358,6 +376,11 @@ update(T & v, const a_Type &a,
     const T3 & v3, const d_Type &d,
     const T4 & v4, const e_Type &e)
 {
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v1, 0));
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v2, 0));
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v3, 0));
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v4, 0));
+
   using scalar_t = typename ::pressio::Traits<T>::scalar_type;
   static_assert(impl:: _kokkosUpdateAdmissibleOperands<scalar_t,T,T1,T2,T3,T4>::value,"");
 
@@ -414,6 +437,11 @@ update(T & v,
     const T3 & v3, const d_Type &d,
     const T4 & v4, const e_Type &e)
 {
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v1, 0));
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v2, 0));
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v3, 0));
+  assert(::pressio::ops::extent(v, 0) == ::pressio::ops::extent(v4, 0));
+
   using scalar_t = typename ::pressio::Traits<T>::scalar_type;
   static_assert(impl::_kokkosUpdateAdmissibleOperands<scalar_t,T,T1,T2,T3,T4>::value,"");
 

--- a/include/pressio/ops/kokkos/ops_vector_update.hpp
+++ b/include/pressio/ops/kokkos/ops_vector_update.hpp
@@ -99,7 +99,9 @@ update(T & v, const a_Type &a,
 
   using scalar_t = typename ::pressio::Traits<T>::scalar_type;
   static_assert(impl::_kokkosUpdateAdmissibleOperands<scalar_t,T,T1>::value,"");
-  ::KokkosBlas::axpby(b, impl::get_native(v1), a, impl::get_native(v));
+  scalar_t a_{a};
+  scalar_t b_{b};
+  ::KokkosBlas::axpby(b_, impl::get_native(v1), a_, impl::get_native(v));
 }
 
 template<typename T, typename T1, typename T2, typename b_Type>
@@ -127,8 +129,9 @@ update(T & v, const T1 & v1, const b_Type &b)
 
   using scalar_t = typename ::pressio::Traits<T>::scalar_type;
   static_assert(impl::_kokkosUpdateAdmissibleOperands<scalar_t, T1,T2>::value,"");
+  scalar_t b_{b};
   constexpr auto zero = ::pressio::utils::Constants<scalar_t>::zero();
-  ::KokkosBlas::axpby(b, impl::get_native(v1), zero, impl::get_native(v));
+  ::KokkosBlas::axpby(b_, impl::get_native(v1), zero, impl::get_native(v));
 }
 
 //----------------------------------------------------------------------
@@ -168,6 +171,10 @@ update(T & v, const a_Type &a,
   using scalar_t = typename ::pressio::Traits<T>::scalar_type;
   static_assert(impl::_kokkosUpdateAdmissibleOperands<scalar_t,T,T1,T2>::value,"");
 
+  scalar_t a_{a};
+  scalar_t b_{b};
+  scalar_t c_{c};
+
   using v_t = typename impl::NativeType<T>::type;
   using v1_t = typename impl::NativeType<T1>::type;
   using v2_t = typename impl::NativeType<T2>::type;
@@ -175,7 +182,7 @@ update(T & v, const a_Type &a,
   using fnctr_t = ::pressio::ops::impl::DoUpdateTwoTermsFunctor<v_t,v1_t,v2_t,scalar_t>;
   fnctr_t F(impl::get_native(v),
             impl::get_native(v1),
-            impl::get_native(v2), a, b, c);
+            impl::get_native(v2), a_, b_, c_);
   Kokkos::parallel_for(v.extent(0), F);
 }
 
@@ -212,6 +219,9 @@ update(T & v,
   using scalar_t = typename ::pressio::Traits<T>::scalar_type;
   static_assert(impl::_kokkosUpdateAdmissibleOperands<scalar_t,T,T1,T2>::value,"");
 
+  scalar_t b_{b};
+  scalar_t c_{c};
+
   using v_t = typename impl::NativeType<T>::type;
   using v1_t = typename impl::NativeType<T1>::type;
   using v2_t = typename impl::NativeType<T2>::type;
@@ -219,7 +229,7 @@ update(T & v,
   using fnctr_t = ::pressio::ops::impl::DoUpdateTwoTermsFunctor<v_t,v1_t,v2_t,scalar_t>;
   fnctr_t F(impl::get_native(v),
             impl::get_native(v1),
-            impl::get_native(v2), b, c);
+            impl::get_native(v2), b_, c_);
   Kokkos::parallel_for(v.extent(0), F);
 }
 
@@ -267,6 +277,11 @@ update(T & v, const a_Type &a,
   using scalar_t = typename ::pressio::Traits<T>::scalar_type;
   static_assert(impl::_kokkosUpdateAdmissibleOperands<scalar_t,T,T1,T2,T3>::value,"");
 
+  scalar_t a_{a};
+  scalar_t b_{b};
+  scalar_t c_{c};
+  scalar_t d_{d};
+
   using v_t = typename impl::NativeType<T>::type;
   using v1_t = typename impl::NativeType<T1>::type;
   using v2_t = typename impl::NativeType<T2>::type;
@@ -277,7 +292,7 @@ update(T & v, const a_Type &a,
             impl::get_native(v1),
             impl::get_native(v2),
             impl::get_native(v3),
-            a, b, c, d);
+            a_, b_, c_, d_);
   Kokkos::parallel_for(v.extent(0), F);
 }
 
@@ -320,6 +335,10 @@ update(T & v,
   using scalar_t = typename ::pressio::Traits<T>::scalar_type;
   static_assert(impl::_kokkosUpdateAdmissibleOperands<scalar_t,T,T1,T2,T3>::value,"");
 
+  scalar_t b_{b};
+  scalar_t c_{c};
+  scalar_t d_{d};
+
   using v_t = typename impl::NativeType<T>::type;
   using v1_t = typename impl::NativeType<T1>::type;
   using v2_t = typename impl::NativeType<T2>::type;
@@ -330,7 +349,7 @@ update(T & v,
             impl::get_native(v1),
             impl::get_native(v2),
             impl::get_native(v3),
-            b, c, d);
+            b_, c_, d_);
   Kokkos::parallel_for(v.extent(0), F);
 }
 
@@ -384,6 +403,12 @@ update(T & v, const a_Type &a,
   using scalar_t = typename ::pressio::Traits<T>::scalar_type;
   static_assert(impl:: _kokkosUpdateAdmissibleOperands<scalar_t,T,T1,T2,T3,T4>::value,"");
 
+  scalar_t a_{a};
+  scalar_t b_{b};
+  scalar_t c_{c};
+  scalar_t d_{d};
+  scalar_t e_{e};
+
   using v_t = typename impl::NativeType<T>::type;
   using v1_t = typename impl::NativeType<T1>::type;
   using v2_t = typename impl::NativeType<T2>::type;
@@ -396,7 +421,7 @@ update(T & v, const a_Type &a,
             impl::get_native(v2),
             impl::get_native(v3),
             impl::get_native(v4),
-            a, b, c, d, e);
+            a_, b_, c_, d_, e_);
   Kokkos::parallel_for(v.extent(0), F);
 }
 
@@ -445,6 +470,11 @@ update(T & v,
   using scalar_t = typename ::pressio::Traits<T>::scalar_type;
   static_assert(impl::_kokkosUpdateAdmissibleOperands<scalar_t,T,T1,T2,T3,T4>::value,"");
 
+  scalar_t b_{b};
+  scalar_t c_{c};
+  scalar_t d_{d};
+  scalar_t e_{e};
+
   using v_t = typename impl::NativeType<T>::type;
   using v1_t = typename impl::NativeType<T1>::type;
   using v2_t = typename impl::NativeType<T2>::type;
@@ -457,7 +487,7 @@ update(T & v,
             impl::get_native(v2),
             impl::get_native(v3),
             impl::get_native(v4),
-            b, c, d, e);
+            b_, c_, d_, e_);
   Kokkos::parallel_for(v.extent(0), F);
 }
 

--- a/include/pressio/ops/kokkos/ops_vector_update.hpp
+++ b/include/pressio/ops/kokkos/ops_vector_update.hpp
@@ -62,7 +62,7 @@ struct _kokkosUpdateAdmissibleOperands
      In kokkos it is legal to modify const views, not for pressio wrappers. */
   static_assert
     (!std::is_const<T1>::value,
-     "ops:product: cannot modify a const-qualified wrapper of a Kokkos view");
+     "ops:update: cannot modify a const-qualified wrapper of a Kokkos view");
 
   static constexpr auto value = true;
 };

--- a/include/pressio/ops/kokkos/ops_vector_update_kokkos_functors.hpp
+++ b/include/pressio/ops/kokkos/ops_vector_update_kokkos_functors.hpp
@@ -72,7 +72,8 @@ struct DoUpdateTwoTermsFunctor {
 
   KOKKOS_INLINE_FUNCTION
   void operator () (const int i) const {
-    v_(i) = a_*v_(i) + b_*v1_(i) + c_*v2_(i);
+    const auto t = b_*v1_(i) + c_*v2_(i);
+    v_(i) = (a_ == ::pressio::utils::Constants<sc_t>::zero()) ? t : a_*v_(i) + t;
   }
 };
 
@@ -99,7 +100,8 @@ struct DoUpdateThreeTermsFunctor {
 
   KOKKOS_INLINE_FUNCTION
   void operator () (const int i) const {
-    v_(i) = a_*v_(i) + b_*v1_(i) + c_*v2_(i) + d_*v3_(i);
+    const auto t = b_*v1_(i) + c_*v2_(i) + d_*v3_(i);
+    v_(i) = (a_ == ::pressio::utils::Constants<sc_t>::zero()) ? t : a_*v_(i) + t;
   }
 };
 
@@ -129,7 +131,8 @@ struct DoUpdateFourTermsFunctor {
 
   KOKKOS_INLINE_FUNCTION
   void operator () (const int i) const {
-    v_(i) = a_*v_(i) + b_*v1_(i) + c_*v2_(i) + d_*v3_(i) + e_*v4_(i);
+    const auto t = b_*v1_(i) + c_*v2_(i) + d_*v3_(i) + e_*v4_(i);
+    v_(i) = (a_ == ::pressio::utils::Constants<sc_t>::zero()) ? t : a_*v_(i) + t;
   }
 };
 

--- a/tests/functional_small/ops/ops_kokkos_vector.cc
+++ b/tests/functional_small/ops/ops_kokkos_vector.cc
@@ -387,6 +387,52 @@ TEST(ops_kokkos, vector_update_nan2)
   EXPECT_DOUBLE_EQ(v_h(0), 4.0);
 }
 
+TEST(ops_kokkos, vector_update_expr_span)
+{
+  Kokkos::View<double*> v0("v_span", 5);
+  Kokkos::View<double*> a0("a_span", 5);
+  auto v = pressio::span(v0, 1, 3);
+  auto a = pressio::span(a0, 1, 3);
+  pressio::ops::fill(v, 10.);
+  pressio::ops::fill(a, 1.);
+
+  pressio::ops::update(v, 1., a, 1.);
+  pressio::ops::update(v, 1., a, 1., a, 2.);
+  pressio::ops::update(v, 1., a, 1., a, 2., a, 3.);
+  pressio::ops::update(v, 1., a, 1., a, 2., a, 3., a, 4.);
+
+  // Note: just check the final result as this test is more about
+  //       whether expressions compile and work than computation itself
+  auto v_h = Kokkos::create_mirror_view_and_copy(
+                Kokkos::HostSpace(), pressio::ops::impl::get_native(v));
+  EXPECT_DOUBLE_EQ( v_h(0), 30.0);
+  EXPECT_DOUBLE_EQ( v_h(1), 30.0);
+  EXPECT_DOUBLE_EQ( v_h(2), 30.0);
+}
+
+TEST(ops_kokkos, vector_update_expr_diag)
+{
+  Kokkos::View<double**> v0("v_diag", 3, 3);
+  Kokkos::View<double**> a0("a_diag", 3, 3);
+  auto v = pressio::diag(v0);
+  auto a = pressio::diag(a0);
+  pressio::ops::fill(v, 10.);
+  pressio::ops::fill(a, 1.);
+
+  pressio::ops::update(v, 1., a, 1.);
+  pressio::ops::update(v, 1., a, 1., a, 2.);
+  pressio::ops::update(v, 1., a, 1., a, 2., a, 3.);
+  pressio::ops::update(v, 1., a, 1., a, 2., a, 3., a, 4.);
+
+  // Note: just check the final result as this test is more about
+  //       whether expressions compile and work than computation itself
+  auto v_h = Kokkos::create_mirror_view_and_copy(
+                Kokkos::HostSpace(), pressio::ops::impl::get_native(v));
+  EXPECT_DOUBLE_EQ( v_h(0), 30.0);
+  EXPECT_DOUBLE_EQ( v_h(1), 30.0);
+  EXPECT_DOUBLE_EQ( v_h(2), 30.0);
+}
+
 TEST(ops_kokkos, vector_elementwiseMultiply)
 {
   Kokkos::View<double*> y("y", 3);

--- a/tests/functional_small/ops/ops_kokkos_vector.cc
+++ b/tests/functional_small/ops/ops_kokkos_vector.cc
@@ -310,45 +310,45 @@ TEST(ops_kokkos, vector_update_nan1)
 {
   Kokkos::View<double*> v("v", 3);
   Kokkos::View<double*> a("a", 3);
-  Kokkos::View<double*> nan("nan", 3);
+  Kokkos::View<double*> vecOfNans("nan", 3);
   pressio::ops::fill(v, 1.);
   pressio::ops::fill(a, 1.);
-  pressio::ops::fill(nan, std::nan("0"));
+  pressio::ops::fill(vecOfNans, std::nan("0"));
 
   // Note: this test covers just enough nan/non-nan combinations
   // to trigger and verify all execution paths in our update()
   // implementations, which include anti-NaN-injection variants
-  pressio::ops::update(v, 1., nan, 0.);
+  pressio::ops::update(v, 1., vecOfNans, 0.);
   auto v_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), v);
   EXPECT_DOUBLE_EQ(v_h(0), 1.0);
 
-  pressio::ops::update(v, 1., nan, 0., nan, 0.);
+  pressio::ops::update(v, 1., vecOfNans, 0., vecOfNans, 0.);
   v_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), v);
   EXPECT_DOUBLE_EQ(v_h(0), 1.0);
-  pressio::ops::update(v, 1., a, 1., nan, 0.);
+  pressio::ops::update(v, 1., a, 1., vecOfNans, 0.);
   v_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), v);
   EXPECT_DOUBLE_EQ(v_h(0), 2.);
 
-  pressio::ops::update(v, 1., nan, 0., nan, 0., nan, 0.);
+  pressio::ops::update(v, 1., vecOfNans, 0., vecOfNans, 0., vecOfNans, 0.);
   v_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), v);
   EXPECT_DOUBLE_EQ(v_h(0), 2.0);
-  pressio::ops::update(v, 1., a, 1., nan, 0., a, 1.);
+  pressio::ops::update(v, 1., a, 1., vecOfNans, 0., a, 1.);
   v_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), v);
   EXPECT_DOUBLE_EQ(v_h(0), 4.);
-  pressio::ops::update(v, 1., a, 1., a, 1., nan, 0.);
+  pressio::ops::update(v, 1., a, 1., a, 1., vecOfNans, 0.);
   v_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), v);
   EXPECT_DOUBLE_EQ(v_h(0), 6.);
 
-  pressio::ops::update(v, 1., nan, 0., nan, 0., nan, 0., nan, 0.);
+  pressio::ops::update(v, 1., vecOfNans, 0., vecOfNans, 0., vecOfNans, 0., vecOfNans, 0.);
   v_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), v);
   EXPECT_DOUBLE_EQ(v_h(0), 6.0);
-  pressio::ops::update(v, 1., a, 1., nan, 0., a, 1., a, 1.);
+  pressio::ops::update(v, 1., a, 1., vecOfNans, 0., a, 1., a, 1.);
   v_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), v);
   EXPECT_DOUBLE_EQ(v_h(0), 9.);
-  pressio::ops::update(v, 1., a, 1., a, 1., nan, 0., a, 1.);
+  pressio::ops::update(v, 1., a, 1., a, 1., vecOfNans, 0., a, 1.);
   v_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), v);
   EXPECT_DOUBLE_EQ(v_h(0), 12.);
-  pressio::ops::update(v, 1., a, 1., a, 1., a, 1., nan, 0.);
+  pressio::ops::update(v, 1., a, 1., a, 1., a, 1., vecOfNans, 0.);
   v_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), v);
   EXPECT_DOUBLE_EQ(v_h(0), 15.);
 }


### PR DESCRIPTION
Contents:
- [x] revised overload constraints 
- [x] added extent checks
- [x] added explicit type casting for coefficients
- [x] fixed NaN injection bug added related unit tests
- [x] added expression unit tests with `span` and `diag`

refs #448