### PR TITLE
ops: kokkos: revise rank-2 `update`

### DIFF
--- a/include/pressio/ops.hpp
+++ b/include/pressio/ops.hpp
@@ -106,6 +106,7 @@ template<class ...> struct matching_extents;
 #include "ops/kokkos/ops_dot.hpp"
 #include "ops/kokkos/ops_pow.hpp"
 #include "ops/kokkos/ops_vector_update.hpp"
+#include "ops/kokkos/ops_rank2_update.hpp"
 #include "ops/kokkos/ops_elementwise_multiply.hpp"
 #include "ops/kokkos/ops_level2.hpp"
 #include "ops/kokkos/ops_level3.hpp"

--- a/include/pressio/ops/kokkos/ops_rank2_update.hpp
+++ b/include/pressio/ops/kokkos/ops_rank2_update.hpp
@@ -84,7 +84,11 @@ update(T & mv, const alpha_t &a,
   assert(::pressio::ops::extent(mv, 0) == ::pressio::ops::extent(mv1, 0));
   assert(::pressio::ops::extent(mv, 1) == ::pressio::ops::extent(mv1, 1));
 
-  ::KokkosBlas::axpby(b, mv1, a, mv);
+  using sc_t = typename ::pressio::Traits<T>::scalar_type;
+  sc_t a_{a};
+  sc_t b_{b};
+
+  ::KokkosBlas::axpby(b_, mv1, a_, mv);
 }
 
 }}//end namespace pressio::ops

--- a/include/pressio/ops/kokkos/ops_rank2_update.hpp
+++ b/include/pressio/ops/kokkos/ops_rank2_update.hpp
@@ -57,13 +57,23 @@ namespace pressio{ namespace ops{
 // overloads for computing: MV = a * MV + b * MV1
 // where MV is an kokkos multivector wrapper
 //----------------------------------------------------------------------
-template<typename T1, typename T2, typename scalar_t>
-// ::pressio::mpl::enable_if_t<
-//   containers::predicates::is_multi_vector_wrapper_kokkos<T1>::value and
-//   containers::predicates::is_multi_vector_wrapper_kokkos<T2>::value
-//   >
-void update(T1 & mv, const scalar_t &a,
-	    const T2 & mv1, const scalar_t &b)
+template<typename T, typename T1, typename alpha_t, typename beta_t>
+::pressio::mpl::enable_if_t<
+  // rank-1 update common constraints
+     ::pressio::Traits<T>::rank == 2
+  && ::pressio::Traits<T1>::rank == 2
+  // TPL/container specific
+  && ::pressio::is_native_container_kokkos<T>::value
+  && ::pressio::is_native_container_kokkos<T1>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<T, T1>::value
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value)
+  && std::is_convertible<alpha_t, typename ::pressio::Traits<T>::scalar_type>::value
+  && std::is_convertible<beta_t, typename ::pressio::Traits<T>::scalar_type>::value
+  >
+update(T & mv, const alpha_t &a,
+       const T1 & mv1, const beta_t &b)
 {
   /* make sure we don't pass const objects to be modified.
      In kokkos it is legal to modify const views, not for pressio wrappers. */

--- a/include/pressio/ops/kokkos/ops_rank2_update.hpp
+++ b/include/pressio/ops/kokkos/ops_rank2_update.hpp
@@ -63,8 +63,10 @@ template<typename T, typename T1, typename alpha_t, typename beta_t>
      ::pressio::Traits<T>::rank == 2
   && ::pressio::Traits<T1>::rank == 2
   // TPL/container specific
-  && ::pressio::is_native_container_kokkos<T>::value
-  && ::pressio::is_native_container_kokkos<T1>::value
+  && (::pressio::is_native_container_kokkos<T>::value
+   || ::pressio::is_expression_acting_on_kokkos<T>::value)
+  && (::pressio::is_native_container_kokkos<T1>::value
+   || ::pressio::is_expression_acting_on_kokkos<T1>::value)
   // scalar compatibility
   && ::pressio::all_have_traits_and_same_scalar<T, T1>::value
   && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
@@ -88,7 +90,9 @@ update(T & mv, const alpha_t &a,
   sc_t a_{a};
   sc_t b_{b};
 
-  ::KokkosBlas::axpby(b_, mv1, a_, mv);
+  auto & mv_n = impl::get_native(mv);
+  const auto & mv1_n = impl::get_native(mv1);
+ ::KokkosBlas::axpby(b_, mv1_n, a_, mv_n);
 }
 
 }}//end namespace pressio::ops

--- a/include/pressio/ops/kokkos/ops_rank2_update.hpp
+++ b/include/pressio/ops/kokkos/ops_rank2_update.hpp
@@ -87,8 +87,8 @@ update(T & mv, const alpha_t &a,
   assert(::pressio::ops::extent(mv, 1) == ::pressio::ops::extent(mv1, 1));
 
   using sc_t = typename ::pressio::Traits<T>::scalar_type;
-  sc_t a_{a};
-  sc_t b_{b};
+  const sc_t a_{a};
+  const sc_t b_{b};
 
   auto & mv_n = impl::get_native(mv);
   const auto & mv1_n = impl::get_native(mv1);

--- a/include/pressio/ops/kokkos/ops_rank2_update.hpp
+++ b/include/pressio/ops/kokkos/ops_rank2_update.hpp
@@ -58,12 +58,12 @@ namespace pressio{ namespace ops{
 // where MV is an kokkos multivector wrapper
 //----------------------------------------------------------------------
 template<typename T1, typename T2, typename scalar_t>
-::pressio::mpl::enable_if_t<
-  containers::predicates::is_multi_vector_wrapper_kokkos<T1>::value and
-  containers::predicates::is_multi_vector_wrapper_kokkos<T2>::value
-  >
-update(T1 & mv,     const scalar_t &a,
-	  const T2 & mv1, const scalar_t &b)
+// ::pressio::mpl::enable_if_t<
+//   containers::predicates::is_multi_vector_wrapper_kokkos<T1>::value and
+//   containers::predicates::is_multi_vector_wrapper_kokkos<T2>::value
+//   >
+void update(T1 & mv, const scalar_t &a,
+	    const T2 & mv1, const scalar_t &b)
 {
   /* make sure we don't pass const objects to be modified.
      In kokkos it is legal to modify const views, not for pressio wrappers. */
@@ -71,7 +71,7 @@ update(T1 & mv,     const scalar_t &a,
     (!std::is_const<T1>::value,
      "cannot modify a const-qualified wrapper of a Kokkos view");
 
-  ::KokkosBlas::axpby(b, *mv1.data(), a, *mv.data());
+  ::KokkosBlas::axpby(b, mv1, a, mv);
 }
 
 }}//end namespace pressio::ops

--- a/include/pressio/ops/kokkos/ops_rank2_update.hpp
+++ b/include/pressio/ops/kokkos/ops_rank2_update.hpp
@@ -81,6 +81,9 @@ update(T & mv, const alpha_t &a,
     (!std::is_const<T1>::value,
      "cannot modify a const-qualified wrapper of a Kokkos view");
 
+  assert(::pressio::ops::extent(mv, 0) == ::pressio::ops::extent(mv1, 0));
+  assert(::pressio::ops::extent(mv, 1) == ::pressio::ops::extent(mv1, 1));
+
   ::KokkosBlas::axpby(b, mv1, a, mv);
 }
 

--- a/tests/functional_small/ops/ops_kokkos_matrix.cc
+++ b/tests/functional_small/ops/ops_kokkos_matrix.cc
@@ -143,3 +143,23 @@ TEST(ops_kokkos, dense_matrix_update)
   EXPECT_DOUBLE_EQ(M_h(1, 0), 0.);
   EXPECT_DOUBLE_EQ(M_h(1, 1), 0.);
 }
+
+TEST(ops_kokkos, dense_matrix_update_epxr)
+{
+  Kokkos::View<double**> M0("M", 4, 4);
+  Kokkos::View<double**> A0("A", 4, 4);
+  pressio::ops::fill(M0, 1);
+  pressio::ops::fill(A0, 2);
+  auto M = pressio::subspan(M0, {1, 3}, {1, 3});
+  auto A = pressio::subspan(A0, {1, 3}, {1, 3});
+
+  pressio::ops::update(M, 2., A, 3.);
+  auto M0_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), M0);
+  for (int i = 0; i < 4; ++i) {
+    for (int j = 0; j < 4; ++j) {
+      const bool sub = i > 0 && i < 3 && j > 0 && j < 3;
+      EXPECT_DOUBLE_EQ(M0_h(i, j), sub ? 8.   // updated M
+                                       : 1.); // unmodified part of M0
+    }
+  }
+}

--- a/tests/functional_small/ops/ops_kokkos_matrix.cc
+++ b/tests/functional_small/ops/ops_kokkos_matrix.cc
@@ -113,4 +113,33 @@ TEST(ops_kokkos, dense_matrix_update)
   EXPECT_DOUBLE_EQ(M_h(0, 1), 8.);
   EXPECT_DOUBLE_EQ(M_h(1, 0), 8.);
   EXPECT_DOUBLE_EQ(M_h(1, 1), 8.);
+
+  // NaN injection through alpha=0
+  const auto nan = std::nan("0");
+  pressio::ops::fill(M, nan);
+  pressio::ops::update(M, 0., A, 2.);
+  M_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), M);
+  EXPECT_DOUBLE_EQ(M_h(0, 0), 4.);
+  EXPECT_DOUBLE_EQ(M_h(0, 1), 4.);
+  EXPECT_DOUBLE_EQ(M_h(1, 0), 4.);
+  EXPECT_DOUBLE_EQ(M_h(1, 1), 4.);
+
+  // NaN injection through beta=0
+  pressio::ops::fill(A, nan);
+  pressio::ops::update(M, -1., A, 0.);
+  M_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), M);
+  EXPECT_DOUBLE_EQ(M_h(0, 0), -4.);
+  EXPECT_DOUBLE_EQ(M_h(0, 1), -4.);
+  EXPECT_DOUBLE_EQ(M_h(1, 0), -4.);
+  EXPECT_DOUBLE_EQ(M_h(1, 1), -4.);
+
+  // alpha=beta=0 corner case
+  pressio::ops::fill(M, nan);
+  pressio::ops::fill(A, nan);
+  pressio::ops::update(M, 0., A, 0.);
+  M_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), M);
+  EXPECT_DOUBLE_EQ(M_h(0, 0), 0.);
+  EXPECT_DOUBLE_EQ(M_h(0, 1), 0.);
+  EXPECT_DOUBLE_EQ(M_h(1, 0), 0.);
+  EXPECT_DOUBLE_EQ(M_h(1, 1), 0.);
 }

--- a/tests/functional_small/ops/ops_kokkos_matrix.cc
+++ b/tests/functional_small/ops/ops_kokkos_matrix.cc
@@ -6,7 +6,7 @@ TEST(ops_kokkos, dense_matrix_clone)
 {
   Kokkos::View<double**> A("A", 6,8);
   auto A_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), A);
-  int c=0;  
+  int c=0;
   for (int i=0; i<6; ++i){
     for (int j=0; j<8; ++j){
      A_h(i,j)= (double) ++c;
@@ -98,4 +98,19 @@ TEST(ops_kokkos, dense_matrix_deep_copy)
     ASSERT_DOUBLE_EQ(B_h(i,j),44.);
    }
   }
+}
+
+TEST(ops_kokkos, dense_matrix_update)
+{
+  Kokkos::View<double**> M("A", 2, 2);
+  Kokkos::View<double**> A("A", 2, 2);
+  pressio::ops::fill(M, 1.);
+  pressio::ops::fill(A, 2.);
+
+  pressio::ops::update(M, 2., A, 3.);
+  auto M_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), M);
+  EXPECT_DOUBLE_EQ(M_h(0, 0), 8.);
+  EXPECT_DOUBLE_EQ(M_h(0, 1), 8.);
+  EXPECT_DOUBLE_EQ(M_h(1, 0), 8.);
+  EXPECT_DOUBLE_EQ(M_h(1, 1), 8.);
 }


### PR DESCRIPTION
Contents:
- [x] revised overload constraints
- [x] added extent checks
- [x] added explicit type casting for coefficients
- [x] added NaN injection tests (no fix needed)
- [x] fixed no-alpha overload and added related unit tests
- [x] added expression support and related unit tests

refs #449