### PR TITLE
ops: epetra: revise rank-2 `update`

### DIFF
--- a/include/pressio/ops/epetra/ops_multi_vector_update.hpp
+++ b/include/pressio/ops/epetra/ops_multi_vector_update.hpp
@@ -72,6 +72,9 @@ template<typename T, typename T1, typename alpha_t, typename beta_t>
 update(T & mv, const alpha_t &a,
        const T1 & mv1, const beta_t &b)
 {
+  assert(::pressio::ops::extent(mv, 0) == ::pressio::ops::extent(mv1, 0));
+  assert(::pressio::ops::extent(mv, 1) == ::pressio::ops::extent(mv1, 1));
+
   mv.Update(b, mv1, a);
 }
 

--- a/include/pressio/ops/epetra/ops_multi_vector_update.hpp
+++ b/include/pressio/ops/epetra/ops_multi_vector_update.hpp
@@ -54,20 +54,46 @@ namespace pressio{ namespace ops{
 //----------------------------------------------------------------------
 //  overloads for computing: MV = a * MV + b * MV1
 //----------------------------------------------------------------------
-template<typename T, typename scalar_t>
-::pressio::mpl::enable_if_t<is_multi_vector_epetra<T>::value>
-update(T & mv, const scalar_t &a,
-	  const T & mv1, const scalar_t &b)
+template<typename T, typename T1, typename alpha_t, typename beta_t>
+::pressio::mpl::enable_if_t<
+  // rank-1 update common constraints
+     ::pressio::Traits<T>::rank == 2
+  && ::pressio::Traits<T1>::rank == 2
+  // TPL/container specific
+  && ::pressio::is_multi_vector_epetra<T>::value
+  && ::pressio::is_multi_vector_epetra<T1>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<T, T1>::value
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value)
+  && std::is_convertible<alpha_t, typename ::pressio::Traits<T>::scalar_type>::value
+  && std::is_convertible<beta_t, typename ::pressio::Traits<T>::scalar_type>::value
+  >
+update(T & mv, const alpha_t &a,
+       const T1 & mv1, const beta_t &b)
 {
   mv.Update(b, mv1, a);
 }
 
-template<typename T, typename scalar_t>
-::pressio::mpl::enable_if_t<::pressio::is_multi_vector_epetra<T>::value>
-update(T & mv, const T & mv1, const scalar_t & b)
+template<typename T, typename T1, typename beta_t>
+::pressio::mpl::enable_if_t<
+  // rank-1 update common constraints
+     ::pressio::Traits<T>::rank == 2
+  && ::pressio::Traits<T1>::rank == 2
+  // TPL/container specific
+  && ::pressio::is_multi_vector_epetra<T>::value
+  && ::pressio::is_multi_vector_epetra<T1>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<T, T1>::value
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value)
+  && std::is_convertible<beta_t, typename ::pressio::Traits<T>::scalar_type>::value
+  >
+update(T & mv, const T1 & mv1, const beta_t & b)
 {
+  using scalar_t = typename ::pressio::Traits<T>::scalar_type;
   constexpr auto zero = ::pressio::utils::Constants<scalar_t>::zero();
-  mv.Update(b, mv1, zero);
+  pressio::ops::update(mv, b, mv1, zero);
 }
 
 }}//end namespace pressio::ops

--- a/include/pressio/ops/epetra/ops_multi_vector_update.hpp
+++ b/include/pressio/ops/epetra/ops_multi_vector_update.hpp
@@ -75,7 +75,11 @@ update(T & mv, const alpha_t &a,
   assert(::pressio::ops::extent(mv, 0) == ::pressio::ops::extent(mv1, 0));
   assert(::pressio::ops::extent(mv, 1) == ::pressio::ops::extent(mv1, 1));
 
-  mv.Update(b, mv1, a);
+  using scalar_t = typename ::pressio::Traits<T>::scalar_type;
+  scalar_t a_{a};
+  scalar_t b_{b};
+
+  mv.Update(b_, mv1, a_);
 }
 
 template<typename T, typename T1, typename beta_t>

--- a/include/pressio/ops/epetra/ops_multi_vector_update.hpp
+++ b/include/pressio/ops/epetra/ops_multi_vector_update.hpp
@@ -76,8 +76,8 @@ update(T & mv, const alpha_t &a,
   assert(::pressio::ops::extent(mv, 1) == ::pressio::ops::extent(mv1, 1));
 
   using scalar_t = typename ::pressio::Traits<T>::scalar_type;
-  scalar_t a_{a};
-  scalar_t b_{b};
+  const scalar_t a_{a};
+  const scalar_t b_{b};
 
   constexpr auto zero = ::pressio::utils::Constants<scalar_t>::zero();
   if (a_ == zero) {

--- a/include/pressio/ops/epetra/ops_multi_vector_update.hpp
+++ b/include/pressio/ops/epetra/ops_multi_vector_update.hpp
@@ -79,7 +79,15 @@ update(T & mv, const alpha_t &a,
   scalar_t a_{a};
   scalar_t b_{b};
 
-  mv.Update(b_, mv1, a_);
+  constexpr auto zero = ::pressio::utils::Constants<scalar_t>::zero();
+  if (a_ == zero) {
+    pressio::ops::set_zero(mv);
+  }
+  if (b_ == zero) {
+    pressio::ops::scale(mv, a_);
+  } else {
+    mv.Update(b_, mv1, a_);
+  }
 }
 
 template<typename T, typename T1, typename beta_t>

--- a/include/pressio/ops/epetra/ops_multi_vector_update.hpp
+++ b/include/pressio/ops/epetra/ops_multi_vector_update.hpp
@@ -81,10 +81,10 @@ update(T & mv, const alpha_t &a,
 
   constexpr auto zero = ::pressio::utils::Constants<scalar_t>::zero();
   if (a_ == zero) {
-    pressio::ops::set_zero(mv);
+    ::pressio::ops::set_zero(mv);
   }
   if (b_ == zero) {
-    pressio::ops::scale(mv, a_);
+    ::pressio::ops::scale(mv, a_);
   } else {
     mv.Update(b_, mv1, a_);
   }
@@ -108,8 +108,8 @@ update(T & mv, const T1 & mv1, const beta_t & b)
 {
   using scalar_t = typename ::pressio::Traits<T>::scalar_type;
   constexpr auto zero = ::pressio::utils::Constants<scalar_t>::zero();
-  pressio::ops::update(mv, b, mv1, zero);
+  ::pressio::ops::update(mv, b, mv1, zero);
 }
 
-}}//end namespace pressio::ops
+}}//end namespace ::pressio::ops
 #endif  // OPS_EPETRA_OPS_MULTI_VECTOR_UPDATE_HPP_

--- a/tests/functional_small/ops/ops_epetra_multi_vector.cc
+++ b/tests/functional_small/ops/ops_epetra_multi_vector.cc
@@ -79,6 +79,12 @@ TEST_F(epetraMultiVectorGlobSize15Fixture, multi_vector_update1_a)
       EXPECT_DOUBLE_EQ(v[j][i], 2.);
      }
     }
+    pressio::ops::update(v, a, 1.);
+    for (int i=0; i<localSize_; ++i){
+     for (int j=0; j<numVecs_; ++j){
+      EXPECT_DOUBLE_EQ(v[j][i], 2.);
+     }
+    }
 }
 
 TEST_F(epetraMultiVectorGlobSize15Fixture, multi_vector_update1_b)

--- a/tests/functional_small/ops/ops_epetra_multi_vector.cc
+++ b/tests/functional_small/ops/ops_epetra_multi_vector.cc
@@ -4,7 +4,7 @@
 
 TEST_F(epetraMultiVectorGlobSize15Fixture, multi_vector_clone)
 {
-    auto a = pressio::ops::clone(*myMv_);
+    auto a = ::pressio::ops::clone(*myMv_);
     ASSERT_TRUE(a.Values() != myMv_->Values());
 
     for (int i=0; i<localSize_; ++i){
@@ -30,8 +30,8 @@ TEST_F(epetraMultiVectorGlobSize15Fixture, multi_vector_extent)
 TEST_F(epetraMultiVectorGlobSize15Fixture, multi_vector_deep_copy)
 {
     myMv_->PutScalar(-5.);
-    auto a = pressio::ops::clone(*myMv_);
-    pressio::ops::deep_copy(a, *myMv_);
+    auto a = ::pressio::ops::clone(*myMv_);
+    ::pressio::ops::deep_copy(a, *myMv_);
     for (int i=0; i<localSize_; ++i){
      for (int j=0; j<numVecs_; ++j){
         EXPECT_DOUBLE_EQ(a[j][i], -5.);
@@ -48,7 +48,7 @@ TEST_F(epetraMultiVectorGlobSize15Fixture, multi_vector_setzero)
      }
     }
 
-    pressio::ops::set_zero(*myMv_);
+    ::pressio::ops::set_zero(*myMv_);
     for (int i=0; i<localSize_; ++i){
      for (int j=0; j<numVecs_; ++j){
         EXPECT_DOUBLE_EQ((*myMv_)[j][i], 0.);
@@ -58,7 +58,7 @@ TEST_F(epetraMultiVectorGlobSize15Fixture, multi_vector_setzero)
 
 TEST_F(epetraMultiVectorGlobSize15Fixture, multi_vector_fill)
 {
-    pressio::ops::fill(*myMv_, 55.);
+    ::pressio::ops::fill(*myMv_, 55.);
     auto & myMv_h = *myMv_;
     for (int i=0; i<localSize_; ++i){
      for (int j=0; j<numVecs_; ++j){
@@ -69,17 +69,17 @@ TEST_F(epetraMultiVectorGlobSize15Fixture, multi_vector_fill)
 
 TEST_F(epetraMultiVectorGlobSize15Fixture, multi_vector_update1_a)
 {
-    auto v = pressio::ops::clone(*myMv_);
-    pressio::ops::fill(v, 1.);
-    auto a = pressio::ops::clone(*myMv_);
-    pressio::ops::fill(a, 2.);
-    pressio::ops::update(v, 0., a, 1.);
+    auto v = ::pressio::ops::clone(*myMv_);
+    ::pressio::ops::fill(v, 1.);
+    auto a = ::pressio::ops::clone(*myMv_);
+    ::pressio::ops::fill(a, 2.);
+    ::pressio::ops::update(v, 0., a, 1.);
     for (int i=0; i<localSize_; ++i){
      for (int j=0; j<numVecs_; ++j){
       EXPECT_DOUBLE_EQ(v[j][i], 2.);
      }
     }
-    pressio::ops::update(v, a, 1.);
+    ::pressio::ops::update(v, a, 1.);
     for (int i=0; i<localSize_; ++i){
      for (int j=0; j<numVecs_; ++j){
       EXPECT_DOUBLE_EQ(v[j][i], 2.);
@@ -89,11 +89,11 @@ TEST_F(epetraMultiVectorGlobSize15Fixture, multi_vector_update1_a)
 
 TEST_F(epetraMultiVectorGlobSize15Fixture, multi_vector_update1_b)
 {
-    auto v = pressio::ops::clone(*myMv_);
-    pressio::ops::fill(v, 1.);
-    auto a = pressio::ops::clone(*myMv_);
-    pressio::ops::fill(a, 2.);
-    pressio::ops::update(v, 1., a, 1.);
+    auto v = ::pressio::ops::clone(*myMv_);
+    ::pressio::ops::fill(v, 1.);
+    auto a = ::pressio::ops::clone(*myMv_);
+    ::pressio::ops::fill(a, 2.);
+    ::pressio::ops::update(v, 1., a, 1.);
     for (int i=0; i<localSize_; ++i){
      for (int j=0; j<numVecs_; ++j){
       EXPECT_DOUBLE_EQ(v[j][i], 3.);
@@ -103,14 +103,14 @@ TEST_F(epetraMultiVectorGlobSize15Fixture, multi_vector_update1_b)
 
 TEST_F(epetraMultiVectorGlobSize15Fixture, multi_vector_update2_nan)
 {
-    auto v = pressio::ops::clone(*myMv_);
-    auto a = pressio::ops::clone(*myMv_);
+    auto v = ::pressio::ops::clone(*myMv_);
+    auto a = ::pressio::ops::clone(*myMv_);
 
     // NaN injection through alpha=0
     const auto nan = std::nan("0");
-    pressio::ops::fill(v, nan);
-    pressio::ops::fill(a, 1.);
-    pressio::ops::update(v, 0., a, 2.);
+    ::pressio::ops::fill(v, nan);
+    ::pressio::ops::fill(a, 1.);
+    ::pressio::ops::update(v, 0., a, 2.);
     for (int i=0; i<localSize_; ++i){
      for (int j=0; j<numVecs_; ++j){
       EXPECT_DOUBLE_EQ(v[j][i], 2.);
@@ -118,8 +118,8 @@ TEST_F(epetraMultiVectorGlobSize15Fixture, multi_vector_update2_nan)
     }
 
     // NaN injection through beta=0
-    pressio::ops::fill(a, nan);
-    pressio::ops::update(v, -1., a, 0.);
+    ::pressio::ops::fill(a, nan);
+    ::pressio::ops::update(v, -1., a, 0.);
     for (int i=0; i<localSize_; ++i){
      for (int j=0; j<numVecs_; ++j){
       EXPECT_DOUBLE_EQ(v[j][i], -2.);
@@ -127,8 +127,8 @@ TEST_F(epetraMultiVectorGlobSize15Fixture, multi_vector_update2_nan)
     }
 
     // alpha=beta=0 corner case
-    pressio::ops::fill(v, nan);
-    pressio::ops::update(v, 0., a, 0.);
+    ::pressio::ops::fill(v, nan);
+    ::pressio::ops::update(v, 0., a, 0.);
     for (int i=0; i<localSize_; ++i){
      for (int j=0; j<numVecs_; ++j){
       EXPECT_DOUBLE_EQ(v[j][i], 0.);

--- a/tests/functional_small/ops/ops_epetra_multi_vector.cc
+++ b/tests/functional_small/ops/ops_epetra_multi_vector.cc
@@ -100,3 +100,38 @@ TEST_F(epetraMultiVectorGlobSize15Fixture, multi_vector_update1_b)
      }
     }
 }
+
+TEST_F(epetraMultiVectorGlobSize15Fixture, multi_vector_update2_nan)
+{
+    auto v = pressio::ops::clone(*myMv_);
+    auto a = pressio::ops::clone(*myMv_);
+
+    // NaN injection through alpha=0
+    const auto nan = std::nan("0");
+    pressio::ops::fill(v, nan);
+    pressio::ops::fill(a, 1.);
+    pressio::ops::update(v, 0., a, 2.);
+    for (int i=0; i<localSize_; ++i){
+     for (int j=0; j<numVecs_; ++j){
+      EXPECT_DOUBLE_EQ(v[j][i], 2.);
+     }
+    }
+
+    // NaN injection through beta=0
+    pressio::ops::fill(a, nan);
+    pressio::ops::update(v, -1., a, 0.);
+    for (int i=0; i<localSize_; ++i){
+     for (int j=0; j<numVecs_; ++j){
+      EXPECT_DOUBLE_EQ(v[j][i], -2.);
+     }
+    }
+
+    // alpha=beta=0 corner case
+    pressio::ops::fill(v, nan);
+    pressio::ops::update(v, 0., a, 0.);
+    for (int i=0; i<localSize_; ++i){
+     for (int j=0; j<numVecs_; ++j){
+      EXPECT_DOUBLE_EQ(v[j][i], 0.);
+     }
+    }
+}


### PR DESCRIPTION
Contents:
- [x] revised overload constraints
- [x] added extent checks
- [x] added explicit type casting for coefficients
- [x] fixed NaN injection bug and added related unit tests
- [x] covered no-alpha overload in unit tests

refs #449