### PR TITLE
ops: tpetra: revise rank-2 `update`

### DIFF
--- a/include/pressio/ops/tpetra/ops_multi_vector_update.hpp
+++ b/include/pressio/ops/tpetra/ops_multi_vector_update.hpp
@@ -102,8 +102,8 @@ update(T & mv, const T1 & mv1, const b_t & b)
 {
   using scalar_t = typename ::pressio::Traits<T>::scalar_type;
   constexpr auto zero = ::pressio::utils::Constants<scalar_t>::zero();
-  pressio::ops::update(mv, zero, mv1, b);
+  ::pressio::ops::update(mv, zero, mv1, b);
 }
 
-}}//end namespace pressio::ops
+}}//end namespace ::pressio::ops
 #endif  // OPS_TPETRA_OPS_MULTI_VECTOR_UPDATE_HPP_

--- a/include/pressio/ops/tpetra/ops_multi_vector_update.hpp
+++ b/include/pressio/ops/tpetra/ops_multi_vector_update.hpp
@@ -74,6 +74,9 @@ template<typename T, typename T1, typename a_t, typename b_t>
 update(T & mv, const a_t &a,
        const T1 & mv1, const b_t &b)
 {
+  assert(::pressio::ops::extent(mv, 0) == ::pressio::ops::extent(mv1, 0));
+  assert(::pressio::ops::extent(mv, 1) == ::pressio::ops::extent(mv1, 1));
+
   mv.update(b, mv1, a);
 }
 

--- a/include/pressio/ops/tpetra/ops_multi_vector_update.hpp
+++ b/include/pressio/ops/tpetra/ops_multi_vector_update.hpp
@@ -56,26 +56,46 @@ namespace pressio{ namespace ops{
 // where MV is an tpetra multivector wrapper
 //----------------------------------------------------------------------
 
-template<typename T, class T2, typename a_t, class b_t>
+template<typename T, typename T1, typename a_t, typename b_t>
 ::pressio::mpl::enable_if_t<
-  is_multi_vector_tpetra<T>::value
-  && is_multi_vector_tpetra<T2>::value
+  // rank-1 update common constraints
+     ::pressio::Traits<T>::rank == 2
+  && ::pressio::Traits<T1>::rank == 2
+  // TPL/container specific
+  && ::pressio::is_multi_vector_tpetra<T>::value
+  && ::pressio::is_multi_vector_tpetra<T1>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<T, T1>::value
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value)
+  && std::is_convertible<a_t, typename ::pressio::Traits<T>::scalar_type>::value
+  && std::is_convertible<b_t, typename ::pressio::Traits<T>::scalar_type>::value
   >
 update(T & mv, const a_t &a,
-       const T2 & mv1, const b_t &b)
+       const T1 & mv1, const b_t &b)
 {
   mv.update(b, mv1, a);
 }
 
-template<typename T, class T2, typename scalar_t>
+template<typename T, typename T1, typename b_t>
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_multi_vector_tpetra<T>::value
-  && ::pressio::is_multi_vector_tpetra<T2>::value
+  // rank-1 update common constraints
+     ::pressio::Traits<T>::rank == 2
+  && ::pressio::Traits<T1>::rank == 2
+  // TPL/container specific
+  && ::pressio::is_multi_vector_tpetra<T>::value
+  && ::pressio::is_multi_vector_tpetra<T1>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<T, T1>::value
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value)
+  && std::is_convertible<b_t, typename ::pressio::Traits<T>::scalar_type>::value
   >
-update(T & mv, const T2 & mv1, const scalar_t & b)
+update(T & mv, const T1 & mv1, const b_t & b)
 {
+  using scalar_t = typename ::pressio::Traits<T>::scalar_type;
   constexpr auto zero = ::pressio::utils::Constants<scalar_t>::zero();
-  mv.update(b, mv1, zero);
+  pressio::ops::update(mv, zero, mv1, b);
 }
 
 }}//end namespace pressio::ops

--- a/include/pressio/ops/tpetra/ops_multi_vector_update.hpp
+++ b/include/pressio/ops/tpetra/ops_multi_vector_update.hpp
@@ -78,8 +78,8 @@ update(T & mv, const a_t &a,
   assert(::pressio::ops::extent(mv, 1) == ::pressio::ops::extent(mv1, 1));
 
   using scalar_t = typename ::pressio::Traits<T>::scalar_type;
-  scalar_t a_{a};
-  scalar_t b_{b};
+  const scalar_t a_{a};
+  const scalar_t b_{b};
 
   mv.update(b_, mv1, a_);
 }

--- a/include/pressio/ops/tpetra/ops_multi_vector_update.hpp
+++ b/include/pressio/ops/tpetra/ops_multi_vector_update.hpp
@@ -77,7 +77,11 @@ update(T & mv, const a_t &a,
   assert(::pressio::ops::extent(mv, 0) == ::pressio::ops::extent(mv1, 0));
   assert(::pressio::ops::extent(mv, 1) == ::pressio::ops::extent(mv1, 1));
 
-  mv.update(b, mv1, a);
+  using scalar_t = typename ::pressio::Traits<T>::scalar_type;
+  scalar_t a_{a};
+  scalar_t b_{b};
+
+  mv.update(b_, mv1, a_);
 }
 
 template<typename T, typename T1, typename b_t>

--- a/include/pressio/ops/tpetra/ops_multi_vector_update.hpp
+++ b/include/pressio/ops/tpetra/ops_multi_vector_update.hpp
@@ -72,7 +72,7 @@ template<typename T, class T2, typename scalar_t>
   ::pressio::is_multi_vector_tpetra<T>::value
   && ::pressio::is_multi_vector_tpetra<T2>::value
   >
-update(T & mv, const T & mv1, const scalar_t & b)
+update(T & mv, const T2 & mv1, const scalar_t & b)
 {
   constexpr auto zero = ::pressio::utils::Constants<scalar_t>::zero();
   mv.update(b, mv1, zero);

--- a/tests/functional_small/ops/ops_tpetra_multi_vector.cc
+++ b/tests/functional_small/ops/ops_tpetra_multi_vector.cc
@@ -4,7 +4,7 @@
 
 TEST_F(tpetraMultiVectorGlobSize15Fixture, multi_vector_clone)
 {
-    auto a = pressio::ops::clone(*myMv_);
+    auto a = ::pressio::ops::clone(*myMv_);
     auto a_h = a.getLocalViewHost(Tpetra::Access::ReadOnly);
     auto myMv_h = myMv_->getLocalViewDevice(Tpetra::Access::ReadOnly);
     ASSERT_NE(a_h.data(), myMv_h.data());
@@ -39,18 +39,18 @@ TEST_F(tpetraMultiVectorGlobSize15Fixture, multi_vector_setzero)
      }
     }
 
-    pressio::ops::set_zero(*myMv_);
+    ::pressio::ops::set_zero(*myMv_);
     auto myMv_h2 = myMv_->getLocalViewHost(Tpetra::Access::ReadWriteStruct());
     for (int i=0; i<localSize_; ++i){
      for (int j=0; j<numVecs_; ++j){
         EXPECT_DOUBLE_EQ(myMv_h2(i,j), 0.);
-     } 
+     }
     }
 }
 
 TEST_F(tpetraMultiVectorGlobSize15Fixture, multi_vector_fill)
 {
-    pressio::ops::fill(*myMv_, 55.);
+    ::pressio::ops::fill(*myMv_, 55.);
     auto myMv_h = myMv_->getLocalViewHost(Tpetra::Access::ReadWriteStruct());
     for (int i=0; i<localSize_; ++i){
      for (int j=0; j<numVecs_; ++j){
@@ -61,13 +61,13 @@ TEST_F(tpetraMultiVectorGlobSize15Fixture, multi_vector_fill)
 
 TEST_F(tpetraMultiVectorGlobSize15Fixture, multi_vector_deep_copy)
 {
-    pressio::ops::fill(*myMv_, -5.);
-    auto a = pressio::ops::clone(*myMv_);
-    pressio::ops::deep_copy(a, *myMv_);
+    ::pressio::ops::fill(*myMv_, -5.);
+    auto a = ::pressio::ops::clone(*myMv_);
+    ::pressio::ops::deep_copy(a, *myMv_);
 
     auto a_h = a.getLocalViewHost(Tpetra::Access::ReadWriteStruct());
     for (int i=0; i<localSize_; ++i){
-     for (int j=0; j<numVecs_; ++j){        
+     for (int j=0; j<numVecs_; ++j){
         EXPECT_DOUBLE_EQ(a_h(i,j), -5.);
      }
     }
@@ -75,18 +75,18 @@ TEST_F(tpetraMultiVectorGlobSize15Fixture, multi_vector_deep_copy)
 
 TEST_F(tpetraMultiVectorGlobSize15Fixture, multi_vector_update1_a)
 {
-    auto v = pressio::ops::clone(*myMv_);
-    pressio::ops::fill(v, 1.);
-    auto a = pressio::ops::clone(*myMv_);
-    pressio::ops::fill(a, 2.);
-    pressio::ops::update(v, 0., a, 1.);
+    auto v = ::pressio::ops::clone(*myMv_);
+    ::pressio::ops::fill(v, 1.);
+    auto a = ::pressio::ops::clone(*myMv_);
+    ::pressio::ops::fill(a, 2.);
+    ::pressio::ops::update(v, 0., a, 1.);
     auto v_h = v.getLocalViewHost(Tpetra::Access::ReadWriteStruct());
     for (int i=0; i<localSize_; ++i){
      for (int j=0; j<numVecs_; ++j){
       EXPECT_DOUBLE_EQ(v_h(i,j), 2.);
      }
     }
-    pressio::ops::update(v, a, 1.);
+    ::pressio::ops::update(v, a, 1.);
     for (int i=0; i<localSize_; ++i){
      for (int j=0; j<numVecs_; ++j){
       EXPECT_DOUBLE_EQ(v_h(i,j), 2.);
@@ -96,11 +96,11 @@ TEST_F(tpetraMultiVectorGlobSize15Fixture, multi_vector_update1_a)
 
 TEST_F(tpetraMultiVectorGlobSize15Fixture, multi_vector_update1_b)
 {
-    auto v = pressio::ops::clone(*myMv_);
-    pressio::ops::fill(v, 1.);
-    auto a = pressio::ops::clone(*myMv_);
-    pressio::ops::fill(a, 2.);
-    pressio::ops::update(v, 1.0, a, 1.);
+    auto v = ::pressio::ops::clone(*myMv_);
+    ::pressio::ops::fill(v, 1.);
+    auto a = ::pressio::ops::clone(*myMv_);
+    ::pressio::ops::fill(a, 2.);
+    ::pressio::ops::update(v, 1.0, a, 1.);
     auto v_h = v.getLocalViewHost(Tpetra::Access::ReadWriteStruct());
     for (int i=0; i<localSize_; ++i){
      for (int j=0; j<numVecs_; ++j){
@@ -111,15 +111,15 @@ TEST_F(tpetraMultiVectorGlobSize15Fixture, multi_vector_update1_b)
 
 TEST_F(tpetraMultiVectorGlobSize15Fixture, multi_vector_update2_nan)
 {
-    auto v = pressio::ops::clone(*myMv_);
-    auto a = pressio::ops::clone(*myMv_);
+    auto v = ::pressio::ops::clone(*myMv_);
+    auto a = ::pressio::ops::clone(*myMv_);
     auto v_h = v.getLocalViewHost(Tpetra::Access::ReadOnly);
 
     // NaN injection through alpha=0
     const auto nan = std::nan("0");
-    pressio::ops::fill(v, nan);
-    pressio::ops::fill(a, 1.);
-    pressio::ops::update(v, 0., a, 2.);
+    ::pressio::ops::fill(v, nan);
+    ::pressio::ops::fill(a, 1.);
+    ::pressio::ops::update(v, 0., a, 2.);
     for (int i = 0; i < localSize_; ++i) {
       for (int j = 0; j < numVecs_; ++j) {
         EXPECT_DOUBLE_EQ(v_h(i, j), 2.);
@@ -127,8 +127,8 @@ TEST_F(tpetraMultiVectorGlobSize15Fixture, multi_vector_update2_nan)
     }
 
     // NaN injection through beta=0
-    pressio::ops::fill(a, nan);
-    pressio::ops::update(v, -1., a, 0.);
+    ::pressio::ops::fill(a, nan);
+    ::pressio::ops::update(v, -1., a, 0.);
     for (int i = 0; i < localSize_; ++i) {
       for (int j = 0; j < numVecs_; ++j) {
         EXPECT_DOUBLE_EQ(v_h(i, j), -2.);
@@ -136,8 +136,8 @@ TEST_F(tpetraMultiVectorGlobSize15Fixture, multi_vector_update2_nan)
     }
 
     // alpha=beta=0 corner case
-    pressio::ops::fill(v, nan);
-    pressio::ops::update(v, 0., a, 0.);
+    ::pressio::ops::fill(v, nan);
+    ::pressio::ops::update(v, 0., a, 0.);
     for (int i = 0; i < localSize_; ++i) {
       for (int j = 0; j < numVecs_; ++j) {
         EXPECT_DOUBLE_EQ(v_h(i, j), 0.);

--- a/tests/functional_small/ops/ops_tpetra_multi_vector.cc
+++ b/tests/functional_small/ops/ops_tpetra_multi_vector.cc
@@ -86,6 +86,12 @@ TEST_F(tpetraMultiVectorGlobSize15Fixture, multi_vector_update1_a)
       EXPECT_DOUBLE_EQ(v_h(i,j), 2.);
      }
     }
+    pressio::ops::update(v, a, 1.);
+    for (int i=0; i<localSize_; ++i){
+     for (int j=0; j<numVecs_; ++j){
+      EXPECT_DOUBLE_EQ(v_h(i,j), 2.);
+     }
+    }
 }
 
 TEST_F(tpetraMultiVectorGlobSize15Fixture, multi_vector_update1_b)

--- a/tests/functional_small/ops/ops_tpetra_multi_vector.cc
+++ b/tests/functional_small/ops/ops_tpetra_multi_vector.cc
@@ -108,3 +108,39 @@ TEST_F(tpetraMultiVectorGlobSize15Fixture, multi_vector_update1_b)
      }
     }
 }
+
+TEST_F(tpetraMultiVectorGlobSize15Fixture, multi_vector_update2_nan)
+{
+    auto v = pressio::ops::clone(*myMv_);
+    auto a = pressio::ops::clone(*myMv_);
+    auto v_h = v.getLocalViewHost(Tpetra::Access::ReadOnly);
+
+    // NaN injection through alpha=0
+    const auto nan = std::nan("0");
+    pressio::ops::fill(v, nan);
+    pressio::ops::fill(a, 1.);
+    pressio::ops::update(v, 0., a, 2.);
+    for (int i = 0; i < localSize_; ++i) {
+      for (int j = 0; j < numVecs_; ++j) {
+        EXPECT_DOUBLE_EQ(v_h(i, j), 2.);
+      }
+    }
+
+    // NaN injection through beta=0
+    pressio::ops::fill(a, nan);
+    pressio::ops::update(v, -1., a, 0.);
+    for (int i = 0; i < localSize_; ++i) {
+      for (int j = 0; j < numVecs_; ++j) {
+        EXPECT_DOUBLE_EQ(v_h(i, j), -2.);
+      }
+    }
+
+    // alpha=beta=0 corner case
+    pressio::ops::fill(v, nan);
+    pressio::ops::update(v, 0., a, 0.);
+    for (int i = 0; i < localSize_; ++i) {
+      for (int j = 0; j < numVecs_; ++j) {
+        EXPECT_DOUBLE_EQ(v_h(i, j), 0.);
+      }
+    }
+}


### PR DESCRIPTION
Contents:
- [x] revised overload constraints
- [x] added extent checks
- [x] added explicit type casting for coefficients
- [x] fixed NaN injection bug and added related unit tests
- [x] fixed no-alpha overload and added related unit tests

refs #449