### PR TITLE
ops: tpetra-block: revise rank-2 `update`

### DIFF
--- a/include/pressio/ops/tpetra_block/ops_multi_vector_update.hpp
+++ b/include/pressio/ops/tpetra_block/ops_multi_vector_update.hpp
@@ -102,8 +102,8 @@ update(T & mv, const T1 & mv1, const b_t & b)
 {
   using scalar_t = typename ::pressio::Traits<T>::scalar_type;
   constexpr auto zero = ::pressio::utils::Constants<scalar_t>::zero();
-  pressio::ops::update(mv, zero, mv1, b);
+  ::pressio::ops::update(mv, zero, mv1, b);
 }
 
-}}//end namespace pressio::ops
+}}//end namespace ::pressio::ops
 #endif  // OPS_TPETRA_BLOCK_OPS_MULTI_VECTOR_UPDATE_HPP_

--- a/include/pressio/ops/tpetra_block/ops_multi_vector_update.hpp
+++ b/include/pressio/ops/tpetra_block/ops_multi_vector_update.hpp
@@ -78,8 +78,8 @@ update(T & mv, const a_t &a,
   assert(::pressio::ops::extent(mv, 1) == ::pressio::ops::extent(mv1, 1));
 
   using scalar_t = typename ::pressio::Traits<T>::scalar_type;
-  scalar_t a_{a};
-  scalar_t b_{b};
+  const scalar_t a_{a};
+  const scalar_t b_{b};
 
   mv.update(b_, mv1, a_);
 }

--- a/include/pressio/ops/tpetra_block/ops_multi_vector_update.hpp
+++ b/include/pressio/ops/tpetra_block/ops_multi_vector_update.hpp
@@ -53,27 +53,49 @@ namespace pressio{ namespace ops{
 
 //----------------------------------------------------------------------
 //  overloads for computing: MV = a * MV + b * MV1
-// where MV is an tpetra multivector wrapper
+// where MV is an tpetra multivector
 //----------------------------------------------------------------------
 
-template<typename T, typename a_t, class b_t>
+template<typename T, typename T1, typename a_t, typename b_t>
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_multi_vector_tpetra_block<T>::value
+  // rank-1 update common constraints
+     ::pressio::Traits<T>::rank == 2
+  && ::pressio::Traits<T1>::rank == 2
+  // TPL/container specific
+  && ::pressio::is_multi_vector_tpetra_block<T>::value
+  && ::pressio::is_multi_vector_tpetra_block<T1>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<T, T1>::value
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value)
+  && std::is_convertible<a_t, typename ::pressio::Traits<T>::scalar_type>::value
+  && std::is_convertible<b_t, typename ::pressio::Traits<T>::scalar_type>::value
   >
 update(T & mv, const a_t &a,
-       const T & mv1, const b_t &b)
+       const T1 & mv1, const b_t &b)
 {
   mv.update(b, mv1, a);
 }
 
-template<typename T, typename scalar_t>
+template<typename T, typename T1, typename b_t>
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_multi_vector_tpetra_block<T>::value
+  // rank-1 update common constraints
+     ::pressio::Traits<T>::rank == 2
+  && ::pressio::Traits<T1>::rank == 2
+  // TPL/container specific
+  && ::pressio::is_multi_vector_tpetra_block<T>::value
+  && ::pressio::is_multi_vector_tpetra_block<T1>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<T, T1>::value
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value)
+  && std::is_convertible<b_t, typename ::pressio::Traits<T>::scalar_type>::value
   >
-update(T & mv, const T & mv1, const scalar_t & b)
+update(T & mv, const T1 & mv1, const b_t & b)
 {
+  using scalar_t = typename ::pressio::Traits<T>::scalar_type;
   constexpr auto zero = ::pressio::utils::Constants<scalar_t>::zero();
-  mv.update(b, mv1, zero);
+  pressio::ops::update(mv, zero, mv1, b);
 }
 
 }}//end namespace pressio::ops

--- a/include/pressio/ops/tpetra_block/ops_multi_vector_update.hpp
+++ b/include/pressio/ops/tpetra_block/ops_multi_vector_update.hpp
@@ -74,7 +74,14 @@ template<typename T, typename T1, typename a_t, typename b_t>
 update(T & mv, const a_t &a,
        const T1 & mv1, const b_t &b)
 {
-  mv.update(b, mv1, a);
+  assert(::pressio::ops::extent(mv, 0) == ::pressio::ops::extent(mv1, 0));
+  assert(::pressio::ops::extent(mv, 1) == ::pressio::ops::extent(mv1, 1));
+
+  using scalar_t = typename ::pressio::Traits<T>::scalar_type;
+  scalar_t a_{a};
+  scalar_t b_{b};
+
+  mv.update(b_, mv1, a_);
 }
 
 template<typename T, typename T1, typename b_t>

--- a/tests/functional_small/ops/ops_tpetra_block_multi_vector.cc
+++ b/tests/functional_small/ops/ops_tpetra_block_multi_vector.cc
@@ -4,7 +4,7 @@
 
 TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture, multi_vector_clone)
 {
-  auto a = pressio::ops::clone(*myMv_);
+  auto a = ::pressio::ops::clone(*myMv_);
   auto a_h = a.getMultiVectorView().getLocalViewDevice(Tpetra::Access::ReadOnly);
   auto myMv_h = myMv_->getMultiVectorView().getLocalViewDevice(Tpetra::Access::ReadOnly);
   ASSERT_NE(a_h.data(), myMv_h.data());
@@ -39,7 +39,7 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture, multi_vector_setz
     }
   }
 
-  pressio::ops::set_zero(*myMv_);
+  ::pressio::ops::set_zero(*myMv_);
   auto myMv_h2 = myMv_->getMultiVectorView().getLocalViewHost(Tpetra::Access::ReadWriteStruct());
   for (int i=0; i<localSize_*blockSize_; ++i){
     for (int j=0; j<numVecs_; ++j){
@@ -50,7 +50,7 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture, multi_vector_setz
 
 TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture, multi_vector_fill)
 {
-  pressio::ops::fill(*myMv_, 55.);
+  ::pressio::ops::fill(*myMv_, 55.);
   auto myMv_h = myMv_->getMultiVectorView().getLocalViewHost(Tpetra::Access::ReadWriteStruct());
   for (int i=0; i<localSize_*blockSize_; ++i){
     for (int j=0; j<numVecs_; ++j){
@@ -61,9 +61,9 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture, multi_vector_fill
 
 TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture, multi_vector_deep_copy)
 {
-  pressio::ops::fill(*myMv_, -5.);
-  auto a = pressio::ops::clone(*myMv_);
-  pressio::ops::deep_copy(a, *myMv_);
+  ::pressio::ops::fill(*myMv_, -5.);
+  auto a = ::pressio::ops::clone(*myMv_);
+  ::pressio::ops::deep_copy(a, *myMv_);
 
   auto a_h = a.getMultiVectorView().getLocalViewHost(Tpetra::Access::ReadWriteStruct());
   for (int i=0; i<localSize_*blockSize_; ++i){
@@ -75,18 +75,18 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture, multi_vector_deep
 
 TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture, multi_vector_update)
 {
-  auto v = pressio::ops::clone(*myMv_);
-  pressio::ops::fill(v, 1.);
-  auto a = pressio::ops::clone(*myMv_);
-  pressio::ops::fill(a, 2.);
-  pressio::ops::update(v, 0., a, 1.);
+  auto v = ::pressio::ops::clone(*myMv_);
+  ::pressio::ops::fill(v, 1.);
+  auto a = ::pressio::ops::clone(*myMv_);
+  ::pressio::ops::fill(a, 2.);
+  ::pressio::ops::update(v, 0., a, 1.);
   auto v_h = v.getMultiVectorView().getLocalViewHost(Tpetra::Access::ReadWriteStruct());
   for (int i=0; i<localSize_*blockSize_; ++i){
     for (int j=0; j<numVecs_; ++j){
       EXPECT_DOUBLE_EQ(v_h(i,j), 2.);
     }
   }
-  pressio::ops::update(v, a, 1.);
+  ::pressio::ops::update(v, a, 1.);
   for (int i=0; i<localSize_*blockSize_; ++i){
     for (int j=0; j<numVecs_; ++j){
       EXPECT_DOUBLE_EQ(v_h(i,j), 2.);
@@ -96,15 +96,15 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture, multi_vector_upda
 
 TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture, multi_vector_update_nan)
 {
-    auto v = pressio::ops::clone(*myMv_);
-    auto a = pressio::ops::clone(*myMv_);
+    auto v = ::pressio::ops::clone(*myMv_);
+    auto a = ::pressio::ops::clone(*myMv_);
     auto v_h = v.getMultiVectorView().getLocalViewHost(Tpetra::Access::ReadOnly);
 
     // NaN injection through alpha=0
     const auto nan = std::nan("0");
-    pressio::ops::fill(v, nan);
-    pressio::ops::fill(a, 1.);
-    pressio::ops::update(v, 0., a, 2.);
+    ::pressio::ops::fill(v, nan);
+    ::pressio::ops::fill(a, 1.);
+    ::pressio::ops::update(v, 0., a, 2.);
     for (int i = 0; i < localSize_; ++i) {
       for (int j = 0; j < numVecs_; ++j) {
         EXPECT_DOUBLE_EQ(v_h(i, j), 2.);
@@ -112,8 +112,8 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture, multi_vector_upda
     }
 
     // NaN injection through beta=0
-    pressio::ops::fill(a, nan);
-    pressio::ops::update(v, -1., a, 0.);
+    ::pressio::ops::fill(a, nan);
+    ::pressio::ops::update(v, -1., a, 0.);
     for (int i = 0; i < localSize_; ++i) {
       for (int j = 0; j < numVecs_; ++j) {
         EXPECT_DOUBLE_EQ(v_h(i, j), -2.);
@@ -121,8 +121,8 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture, multi_vector_upda
     }
 
     // alpha=beta=0 corner case
-    pressio::ops::fill(v, nan);
-    pressio::ops::update(v, 0., a, 0.);
+    ::pressio::ops::fill(v, nan);
+    ::pressio::ops::update(v, 0., a, 0.);
     for (int i = 0; i < localSize_; ++i) {
       for (int j = 0; j < numVecs_; ++j) {
         EXPECT_DOUBLE_EQ(v_h(i, j), 0.);

--- a/tests/functional_small/ops/ops_tpetra_block_multi_vector.cc
+++ b/tests/functional_small/ops/ops_tpetra_block_multi_vector.cc
@@ -86,4 +86,10 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture, multi_vector_upda
       EXPECT_DOUBLE_EQ(v_h(i,j), 2.);
     }
   }
+  pressio::ops::update(v, a, 1.);
+  for (int i=0; i<localSize_*blockSize_; ++i){
+    for (int j=0; j<numVecs_; ++j){
+      EXPECT_DOUBLE_EQ(v_h(i,j), 2.);
+    }
+  }
 }

--- a/tests/functional_small/ops/ops_tpetra_block_multi_vector.cc
+++ b/tests/functional_small/ops/ops_tpetra_block_multi_vector.cc
@@ -93,3 +93,39 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture, multi_vector_upda
     }
   }
 }
+
+TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture, multi_vector_update_nan)
+{
+    auto v = pressio::ops::clone(*myMv_);
+    auto a = pressio::ops::clone(*myMv_);
+    auto v_h = v.getMultiVectorView().getLocalViewHost(Tpetra::Access::ReadOnly);
+
+    // NaN injection through alpha=0
+    const auto nan = std::nan("0");
+    pressio::ops::fill(v, nan);
+    pressio::ops::fill(a, 1.);
+    pressio::ops::update(v, 0., a, 2.);
+    for (int i = 0; i < localSize_; ++i) {
+      for (int j = 0; j < numVecs_; ++j) {
+        EXPECT_DOUBLE_EQ(v_h(i, j), 2.);
+      }
+    }
+
+    // NaN injection through beta=0
+    pressio::ops::fill(a, nan);
+    pressio::ops::update(v, -1., a, 0.);
+    for (int i = 0; i < localSize_; ++i) {
+      for (int j = 0; j < numVecs_; ++j) {
+        EXPECT_DOUBLE_EQ(v_h(i, j), -2.);
+      }
+    }
+
+    // alpha=beta=0 corner case
+    pressio::ops::fill(v, nan);
+    pressio::ops::update(v, 0., a, 0.);
+    for (int i = 0; i < localSize_; ++i) {
+      for (int j = 0; j < numVecs_; ++j) {
+        EXPECT_DOUBLE_EQ(v_h(i, j), 0.);
+      }
+    }
+}


### PR DESCRIPTION
Contents:
- [x] revised overload constraints
- [x] added extent checks
- [x] added explicit type casting for coefficients
- [x] added NaN injection unit tests
- [x] covered no-alpha overload in unit tests

refs #449