### PR TITLE
ops: eigen: cast coefficients to `const` scalar type

### DIFF
--- a/include/pressio/ops/eigen/ops_rank2_update.hpp
+++ b/include/pressio/ops/eigen/ops_rank2_update.hpp
@@ -85,8 +85,8 @@ update(T & M,         const alpha_t & a,
   assert(::pressio::ops::extent(M, 1) == ::pressio::ops::extent(M1, 1));
 
   using sc_t = typename ::pressio::Traits<T>::scalar_type;
-  sc_t a_{a};
-  sc_t b_{b};
+  const sc_t a_{a};
+  const sc_t b_{b};
 
   const auto zero = ::pressio::utils::Constants<sc_t>::zero();
   if (b_ == zero) {


### PR DESCRIPTION
Follows #543: for some reason GitHub refused to acknowledge f80b6fb4eac43dd948a8456c7c6279e74eebf31d as part of [PR#543](https://github.com/Pressio/pressio/pull/543#discussion_r1086445807), so I'm posting it on a new PR

refs #449