### PR TITLE
ops: kokkos: `min`/`max` implementation and tests

### DIFF
--- a/include/pressio/ops.hpp
+++ b/include/pressio/ops.hpp
@@ -102,6 +102,7 @@ template<class ...> struct matching_extents;
 #include "ops/kokkos/ops_fill.hpp"
 #include "ops/kokkos/ops_resize.hpp"
 #include "ops/kokkos/ops_abs.hpp"
+#include "ops/kokkos/ops_min_max.hpp"
 #include "ops/kokkos/ops_norms_vector.hpp"
 #include "ops/kokkos/ops_dot.hpp"
 #include "ops/kokkos/ops_pow.hpp"

--- a/include/pressio/ops/kokkos/ops_min_max.hpp
+++ b/include/pressio/ops/kokkos/ops_min_max.hpp
@@ -1,0 +1,132 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+// ops_min_max.hpp
+//                     		  Pressio
+//                             Copyright 2019
+//    National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+//
+// Under the terms of Contract DE-NA0003525 with NTESS, the
+// U.S. Government retains certain rights in this software.
+//
+// Pressio is licensed under BSD-3-Clause terms of use:
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Francesco Rizzi (fnrizzi@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef OPS_KOKKOS_OPS_MIN_MAX_HPP_
+#define OPS_KOKKOS_OPS_MIN_MAX_HPP_
+
+namespace pressio{ namespace ops{
+
+namespace impl{
+
+template <typename ReducerType, typename ViewType>
+::pressio::mpl::enable_if_t<
+  ViewType::rank == 1,
+  typename ::pressio::Traits<ViewType>::scalar_type
+  >
+kokkos_reduce(const ViewType & view) {
+  using sc_t = typename ::pressio::Traits<ViewType>::scalar_type;
+  sc_t result;
+  ReducerType reducer(result);
+  auto f = KOKKOS_LAMBDA(size_t i, sc_t& r) {
+      reducer.join(r, view(i));
+    };
+  Kokkos::parallel_reduce(
+    "reduce_1d", view.extent(0), f, reducer);
+  return result;
+}
+
+template <typename ReducerType, typename ViewType>
+::pressio::mpl::enable_if_t<
+  ViewType::rank == 2,
+  typename ::pressio::Traits<ViewType>::scalar_type
+  >
+kokkos_reduce(const ViewType & view) {
+  using sc_t = typename ::pressio::Traits<ViewType>::scalar_type;
+  sc_t result;
+  ReducerType reducer(result);
+  Kokkos::MDRangePolicy<Kokkos::Rank<2>> range_2d(
+      {0, 0},
+      {view.extent(0), view.extent(1)}
+    );
+  auto f = KOKKOS_LAMBDA(size_t i0, size_t i1, sc_t& r) {
+      reducer.join(r, view(i0, i1));
+    };
+  Kokkos::parallel_reduce("reduce_2d", range_2d, f, reducer);
+  return result;
+}
+
+}
+
+template <typename T>
+::pressio::mpl::enable_if_t<
+  // TPL/container specific
+    (::pressio::is_native_container_kokkos<T>::value
+  || ::pressio::is_expression_acting_on_kokkos<T>::value)
+  // scalar compatibility
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value),
+  typename ::pressio::Traits<T>::scalar_type
+  >
+max(const T & obj)
+{
+  assert(::pressio::ops::extent(obj, 0) > 0);
+
+  using sc_t = typename ::pressio::Traits<T>::scalar_type;
+  return impl::kokkos_reduce<Kokkos::Max<sc_t>>(impl::get_native(obj));
+}
+
+template <typename T>
+::pressio::mpl::enable_if_t<
+  // TPL/container specific
+    (::pressio::is_native_container_kokkos<T>::value
+  || ::pressio::is_expression_acting_on_kokkos<T>::value)
+  // scalar compatibility
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value),
+  typename ::pressio::Traits<T>::scalar_type
+  >
+min(const T & obj)
+{
+  assert(::pressio::ops::extent(obj, 0) > 0);
+
+  using sc_t = typename ::pressio::Traits<T>::scalar_type;
+  return impl::kokkos_reduce<Kokkos::Min<sc_t>>(impl::get_native(obj));
+}
+
+}}//end namespace pressio::ops
+#endif  // OPS_KOKKOS_OPS_MIN_MAX_HPP_

--- a/include/pressio/ops/kokkos/ops_min_max.hpp
+++ b/include/pressio/ops/kokkos/ops_min_max.hpp
@@ -94,8 +94,11 @@ kokkos_reduce(const ViewType & view) {
 
 template <typename T>
 ::pressio::mpl::enable_if_t<
+  // min/max common constraints
+    (::pressio::Traits<T>::rank == 1
+  || ::pressio::Traits<T>::rank == 2)
   // TPL/container specific
-    (::pressio::is_native_container_kokkos<T>::value
+  && (::pressio::is_native_container_kokkos<T>::value
   || ::pressio::is_expression_acting_on_kokkos<T>::value)
   // scalar compatibility
   && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
@@ -112,8 +115,11 @@ max(const T & obj)
 
 template <typename T>
 ::pressio::mpl::enable_if_t<
+  // min/max common constraints
+    (::pressio::Traits<T>::rank == 1
+  || ::pressio::Traits<T>::rank == 2)
   // TPL/container specific
-    (::pressio::is_native_container_kokkos<T>::value
+  && (::pressio::is_native_container_kokkos<T>::value
   || ::pressio::is_expression_acting_on_kokkos<T>::value)
   // scalar compatibility
   && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value

--- a/tests/functional_small/ops/ops_kokkos_diag.cc
+++ b/tests/functional_small/ops/ops_kokkos_diag.cc
@@ -130,6 +130,20 @@ TEST(ops_kokkos, diag_fill)
   ASSERT_DOUBLE_EQ(a_h(4,4),44.);
 }
 
+TEST(ops_kokkos, diag_min_max)
+{
+  mat_t A("A", 5, 5);
+  auto A_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), A);
+  for (int i = 0; i < 5; ++i) {
+    for (int j = 0; j < 5; ++j) {
+      A_h(i, j) = 100 - i * 5 - j;
+    }
+  }
+  Kokkos::deep_copy(A, A_h);
+  ASSERT_DOUBLE_EQ(pressio::ops::min(A), 76.);
+  ASSERT_DOUBLE_EQ(pressio::ops::max(A), 100.);
+}
+
 TEST(ops_kokkos, diag_norms)
 {
   mat_t a("a",5,5);

--- a/tests/functional_small/ops/ops_kokkos_matrix.cc
+++ b/tests/functional_small/ops/ops_kokkos_matrix.cc
@@ -100,6 +100,20 @@ TEST(ops_kokkos, dense_matrix_deep_copy)
   }
 }
 
+TEST(ops_kokkos, dense_matrix_min_max)
+{
+  Kokkos::View<double**> A("A", 6, 3);
+  auto A_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), A);
+  for (int i = 0; i < 6; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      A_h(i, j) = 100 - i * 6 - j;
+    }
+  }
+  Kokkos::deep_copy(A, A_h);
+  ASSERT_DOUBLE_EQ(pressio::ops::min(A), 68.);
+  ASSERT_DOUBLE_EQ(pressio::ops::max(A), 100.);
+}
+
 TEST(ops_kokkos, dense_matrix_update)
 {
   Kokkos::View<double**> M("A", 2, 2);

--- a/tests/functional_small/ops/ops_kokkos_span.cc
+++ b/tests/functional_small/ops/ops_kokkos_span.cc
@@ -73,6 +73,20 @@ TEST(ops_kokkos, span_fill)
   ASSERT_DOUBLE_EQ(a_h(5),1.2);
 }
 
+TEST(ops_kokkos, span_min_max)
+{
+  vec_t a("a",6);
+  auto a_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), a);
+  for (int i=0; i<6; ++i){
+    a_h(i) = (double) i - 2.0;
+  }
+  Kokkos::deep_copy(a, a_h);
+
+  auto sp = pressio::span(a, 1,3);
+  ASSERT_DOUBLE_EQ(pressio::ops::min(sp), -1.);
+  ASSERT_DOUBLE_EQ(pressio::ops::max(sp), 1.);
+}
+
 TEST(ops_kokkos, span_norms)
 {
   vec_t a("a",6);

--- a/tests/functional_small/ops/ops_kokkos_subspan.cc
+++ b/tests/functional_small/ops/ops_kokkos_subspan.cc
@@ -123,3 +123,19 @@ TEST(ops_kokkos, subspan_fill)
   ASSERT_DOUBLE_EQ(A_h(3,3),1.);
   ASSERT_DOUBLE_EQ(A_h(3,4),1.);
 }
+
+TEST(ops_kokkos, subspan_min_max)
+{
+  mat_t A("A", 6, 6);
+  auto A_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), A);
+  for (int i = 0; i < 6; ++i) {
+    for (int j = 0; j < 6; ++j) {
+      A_h(i, j) = 100 - i * 6 - j;
+    }
+  }
+  Kokkos::deep_copy(A, A_h);
+  auto A1 = pressio::subspan(A, {1, 3}, {2, 4});
+
+  ASSERT_DOUBLE_EQ(pressio::ops::min(A1), 85.);
+  ASSERT_DOUBLE_EQ(pressio::ops::max(A1), 92.);
+}

--- a/tests/functional_small/ops/ops_kokkos_vector.cc
+++ b/tests/functional_small/ops/ops_kokkos_vector.cc
@@ -131,17 +131,18 @@ TEST(ops_kokkos, vector_deep_copy)
   }
 }
 
-// TEST(ops_kokkos, vector_min_max)
-// {
-//   using T = Eigen::VectorXd;
-//   T a(5);
-//   for (int i=0; i<5; ++i){
-//    a(i)= (double) i;
-//   }
+TEST(ops_kokkos, vector_min_max)
+{
+  Kokkos::View<double*> x("x", 6);
+  auto x_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), x);
+  for (int i = 0; i < 6; ++i) {
+    x_h(i) = 100 - i * 5;
+  }
+  Kokkos::deep_copy(x, x_h);
 
-//   ASSERT_DOUBLE_EQ(pressio::ops::min(a), 0.);
-//   ASSERT_DOUBLE_EQ(pressio::ops::max(a), 4.);
-// }
+  ASSERT_DOUBLE_EQ(pressio::ops::min(x), 75.);
+  ASSERT_DOUBLE_EQ(pressio::ops::max(x), 100.);
+}
 
 TEST(ops_kokkos, vector_norm1)
 {


### PR DESCRIPTION
refs #447

### Overloads

Kokkos overloads of `pressio::ops::min` and `pressio::ops::max`:

| function | input | remarks |
|:---:|:---:|:---:|
|`min`<br>`max`|Kokkos view (rank-1 or rank-2)<br>or Kokkos expression| requires underlying scalar type to be known integral of floating-point type|

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_kokkos_vector.cc` | `ops_kokkos.vector_min_max` | `Kokkos::View<double*>` |
| `ops_kokkos_matrix.cc` | `ops_kokkos.dense_matrix_min_max` | `Kokkos::View<double**>` |
| `ops_kokkos_diag.cc` | `ops_kokkos.diag_min_max` | `pressio::diag( Kokkos::View<double**> )` |
| `ops_kokkos_span.cc` | `ops_kokkos.span_min_max` | `pressio::span( Kokkos::View<double*> )` |
| `ops_kokkos_subspan.cc` | `ops_kokkos.subspan_min_max` | `pressio::subspan( Kokkos::View<double**> )` |
