### PR TITLE
ops: epetra: `min`/`max` implementation and tests

### DIFF
--- a/include/pressio/ops.hpp
+++ b/include/pressio/ops.hpp
@@ -161,6 +161,7 @@ template<class ...> struct matching_extents;
 #include "ops/epetra/ops_fill.hpp"
 #include "ops/epetra/ops_abs.hpp"
 #include "ops/epetra/ops_dot.hpp"
+#include "ops/epetra/ops_min_max.hpp"
 #include "ops/epetra/ops_norms.hpp"
 #include "ops/epetra/ops_pow.hpp"
 #include "ops/epetra/ops_rank1_update.hpp"

--- a/include/pressio/ops/epetra/ops_min_max.hpp
+++ b/include/pressio/ops/epetra/ops_min_max.hpp
@@ -1,0 +1,107 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+// ops_min_max.hpp
+//                     		  Pressio
+//                             Copyright 2019
+//    National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+//
+// Under the terms of Contract DE-NA0003525 with NTESS, the
+// U.S. Government retains certain rights in this software.
+//
+// Pressio is licensed under BSD-3-Clause terms of use:
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Francesco Rizzi (fnrizzi@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef OPS_EPETRA_OPS_MIN_MAX_HPP_
+#define OPS_EPETRA_OPS_MIN_MAX_HPP_
+
+namespace pressio{ namespace ops{
+
+template <typename T>
+::pressio::mpl::enable_if_t<
+  // TPL/container specific
+    (::pressio::is_vector_epetra<T>::value
+  || ::pressio::is_multi_vector_epetra<T>::value)
+  // scalar compatibility
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value),
+  typename ::pressio::Traits<T>::scalar_type
+  >
+max(T & obj)
+{
+  assert(::pressio::ops::extent(obj, 0) > 0);
+  assert(!::pressio::is_multi_vector_epetra<T>::value
+       || ::pressio::ops::extent(obj, 1) > 0);
+
+  using sc_t = typename ::pressio::Traits<T>::scalar_type;
+  std::vector<sc_t> x(obj.NumVectors());
+  int ret = obj.MaxValue(x.data());
+  const auto i = std::max_element(x.begin(), x.end());
+  if (i == x.end()) {
+    throw std::runtime_error("Can't take max() of no elements");
+  }
+  return *i;
+}
+
+template <typename T>
+::pressio::mpl::enable_if_t<
+  // TPL/container specific
+    (::pressio::is_vector_epetra<T>::value
+  || ::pressio::is_multi_vector_epetra<T>::value)
+  // scalar compatibility
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value),
+  typename ::pressio::Traits<T>::scalar_type
+  >
+min(const T & obj)
+{
+  assert(::pressio::ops::extent(obj, 0) > 0);
+  assert(!::pressio::is_multi_vector_epetra<T>::value
+       || ::pressio::ops::extent(obj, 1) > 0);
+
+  using sc_t = typename ::pressio::Traits<T>::scalar_type;
+  std::vector<sc_t> x(obj.NumVectors());
+  int ret = obj.MinValue(x.data());
+  const auto i = std::min_element(x.begin(), x.end());
+  if (i == x.end()) {
+    throw std::runtime_error("Can't take min() of no elements");
+  }
+  return *i;
+}
+
+}}//end namespace pressio::ops
+#endif  // OPS_EPETRA_OPS_MIN_MAX_HPP_

--- a/tests/functional_small/ops/ops_epetra_multi_vector.cc
+++ b/tests/functional_small/ops/ops_epetra_multi_vector.cc
@@ -23,8 +23,8 @@ TEST_F(epetraMultiVectorGlobSize15Fixture, multi_vector_clone)
 
 TEST_F(epetraMultiVectorGlobSize15Fixture, multi_vector_extent)
 {
-    ASSERT_TRUE(pressio::ops::extent(*myMv_,0) == 15);
-    ASSERT_TRUE(pressio::ops::extent(*myMv_,1) == 4);
+    ASSERT_TRUE(pressio::ops::extent(*myMv_,0) == numProc_ * localSize_);
+    ASSERT_TRUE(pressio::ops::extent(*myMv_,1) == numVecs_);
 }
 
 TEST_F(epetraMultiVectorGlobSize15Fixture, multi_vector_deep_copy)
@@ -134,4 +134,10 @@ TEST_F(epetraMultiVectorGlobSize15Fixture, multi_vector_update2_nan)
       EXPECT_DOUBLE_EQ(v[j][i], 0.);
      }
     }
+}
+
+TEST_F(epetraMultiVectorGlobSize15Fixture, multi_vector_min_max)
+{
+  ASSERT_DOUBLE_EQ(pressio::ops::min(*myMv_), 1.);
+  ASSERT_DOUBLE_EQ(pressio::ops::max(*myMv_), numProc_ * localSize_ * numVecs_);
 }

--- a/tests/functional_small/ops/ops_epetra_vector.cc
+++ b/tests/functional_small/ops/ops_epetra_vector.cc
@@ -89,6 +89,17 @@ TEST_F(ops_epetra, vector_dot)
   EXPECT_DOUBLE_EQ(res, numProc_ * 5.);
 }
 
+TEST_F(ops_epetra, vector_min_max)
+{
+  auto a = pressio::ops::clone(*myVector_);
+  for (int i = 0; i < localSize_; ++i) {
+    a[i] = 100.0 - (rank_ * localSize_ + i);
+    printf("@ %d:%d -> %g\n", rank_, i, a[i]);
+  }
+  ASSERT_DOUBLE_EQ(pressio::ops::min(a), 100. - (numProc_ * localSize_ - 1.0));
+  ASSERT_DOUBLE_EQ(pressio::ops::max(a), 100.);
+}
+
 TEST_F(ops_epetra, vector_norm2)
 {
   myVector_->PutScalar(1.0);


### PR DESCRIPTION
refs #447

### Overloads

Epetra overloads of `pressio::ops::min` and `pressio::ops::max`:

| function | input | remarks |
|:---:|:---:|:---:|
| `min`<br>`max` | Epetra vector or multi-vector | requires underlying scalar type to be known integral of floating-point type |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_epetra_vector.cc` | `ops_epetra.vector_min_max` | `Epetra_Vector` |
| `ops_epetra_multi_vector.cc` | `epetraMultiVectorGlobSize15Fixture.multi_vector_min_max` | `Epetra_MultiVector` |
