### PR TITLE
ops: tpetra-block: `min`/`max` implementation and tests

### DIFF
--- a/include/pressio/ops.hpp
+++ b/include/pressio/ops.hpp
@@ -147,6 +147,7 @@ template<class ...> struct matching_extents;
 #include "ops/tpetra_block/ops_fill.hpp"
 #include "ops/tpetra_block/ops_abs.hpp"
 #include "ops/tpetra_block/ops_dot.hpp"
+#include "ops/tpetra_block/ops_min_max.hpp"
 #include "ops/tpetra_block/ops_norms.hpp"
 #include "ops/tpetra_block/ops_pow.hpp"
 #include "ops/tpetra_block/ops_rank1_update.hpp"

--- a/include/pressio/ops/tpetra_block/ops_min_max.hpp
+++ b/include/pressio/ops/tpetra_block/ops_min_max.hpp
@@ -1,0 +1,85 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+// ops_min_max.hpp
+//                     		  Pressio
+//                             Copyright 2019
+//    National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+//
+// Under the terms of Contract DE-NA0003525 with NTESS, the
+// U.S. Government retains certain rights in this software.
+//
+// Pressio is licensed under BSD-3-Clause terms of use:
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Francesco Rizzi (fnrizzi@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef OPS_TPETRA_BLOCK_OPS_MIN_MAX_HPP_
+#define OPS_TPETRA_BLOCK_OPS_MIN_MAX_HPP_
+
+namespace pressio{ namespace ops{
+
+template <typename T>
+::pressio::mpl::enable_if_t<
+  // TPL/container specific
+    (::pressio::is_vector_tpetra_block<T>::value
+  || ::pressio::is_multi_vector_tpetra_block<T>::value)
+  // scalar compatibility
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value),
+  typename ::pressio::Traits<T>::scalar_type
+  >
+max(const T & obj)
+{
+  return ::pressio::ops::max(obj.getMultiVectorView());
+}
+
+template <typename T>
+::pressio::mpl::enable_if_t<
+  // TPL/container specific
+    (::pressio::is_vector_tpetra_block<T>::value
+  || ::pressio::is_multi_vector_tpetra_block<T>::value)
+  // scalar compatibility
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value),
+  typename ::pressio::Traits<T>::scalar_type
+  >
+min(const T & obj)
+{
+  return ::pressio::ops::min(obj.getMultiVectorView());
+}
+
+}}//end namespace pressio::ops
+#endif  // OPS_TPETRA_BLOCK_OPS_MIN_MAX_HPP_

--- a/include/pressio/ops/tpetra_block/ops_min_max.hpp
+++ b/include/pressio/ops/tpetra_block/ops_min_max.hpp
@@ -53,8 +53,11 @@ namespace pressio{ namespace ops{
 
 template <typename T>
 ::pressio::mpl::enable_if_t<
+  // min/max common constraints
+    (::pressio::Traits<T>::rank == 1
+  || ::pressio::Traits<T>::rank == 2)
   // TPL/container specific
-    (::pressio::is_vector_tpetra_block<T>::value
+  && (::pressio::is_vector_tpetra_block<T>::value
   || ::pressio::is_multi_vector_tpetra_block<T>::value)
   // scalar compatibility
   && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
@@ -68,8 +71,11 @@ max(const T & obj)
 
 template <typename T>
 ::pressio::mpl::enable_if_t<
+  // min/max common constraints
+    (::pressio::Traits<T>::rank == 1
+  || ::pressio::Traits<T>::rank == 2)
   // TPL/container specific
-    (::pressio::is_vector_tpetra_block<T>::value
+  && (::pressio::is_vector_tpetra_block<T>::value
   || ::pressio::is_multi_vector_tpetra_block<T>::value)
   // scalar compatibility
   && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value

--- a/tests/functional_small/ops/fixtures/tpetra_block_only_fixtures.hpp
+++ b/tests/functional_small/ops/fixtures/tpetra_block_only_fixtures.hpp
@@ -103,10 +103,11 @@ public:
     // initialize data for computations
     myMv_ = std::make_shared<mvec_t>(*contigMap_, blockSize_, numVecs_);
     auto myMv_h = myMv_->getMultiVectorView().getLocalViewHost(Tpetra::Access::ReadWrite);
-    for (int i = 0; i < localSize_; ++i){
+    for (int i = 0; i < localSize_ * blockSize_; ++i){
       for (int j = 0; j < numVecs_; ++j){
         // generate rank-unique int values
-        myMv_h(i, j) = (double)((rank_ * localSize_ + i) * numVecs_ + j + 1.);
+        myMv_h(i, j) = (double)((rank_ * localSize_ * blockSize_ + i) * numVecs_ + j + 1.);
+        printf("\t@ [%d](%d, %d) -> %g\n", rank_, i, j, myMv_h(i, j));
       }
     }
     x_tpetra = std::make_shared<vec_t>(*contigMap_, blockSize_);

--- a/tests/functional_small/ops/ops_tpetra_block_multi_vector.cc
+++ b/tests/functional_small/ops/ops_tpetra_block_multi_vector.cc
@@ -129,3 +129,9 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture, multi_vector_upda
       }
     }
 }
+
+TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture, multi_vector_min_max)
+{
+  ASSERT_DOUBLE_EQ(pressio::ops::min(*myMv_), 1.);
+  ASSERT_DOUBLE_EQ(pressio::ops::max(*myMv_), numProc_ * localSize_ * numVecs_ * blockSize_);
+}

--- a/tests/functional_small/ops/ops_tpetra_block_vector.cc
+++ b/tests/functional_small/ops/ops_tpetra_block_vector.cc
@@ -95,6 +95,20 @@ TEST_F(ops_tpetra_block, vector_dot)
   EXPECT_DOUBLE_EQ(res, numProc_ * 5. * blockSize_);
 }
 
+TEST_F(ops_tpetra_block, vector_min_max)
+{
+  auto a = pressio::ops::clone(*myVector_);
+  auto a_mv = a.getMultiVectorView();
+  auto a2_h = a_mv.getLocalViewHost(Tpetra::Access::ReadWrite);
+  auto a_h = Kokkos::subview(a2_h, Kokkos::ALL, 0);
+  const auto n = localSize_ * blockSize_;
+  for (int i = 0; i < n; ++i) {
+    a_h(i) = 100.0 - (rank_ * n + i);
+  }
+  ASSERT_DOUBLE_EQ(pressio::ops::min(a), 100. - (numProc_ * n - 1.0));
+  ASSERT_DOUBLE_EQ(pressio::ops::max(a), 100.);
+}
+
 TEST_F(ops_tpetra_block, vector_norm2)
 {
   pressio::ops::fill(*myVector_, 1.0);


### PR DESCRIPTION
refs #447

### Overloads

Block Tpetra overloads of `pressio::ops::min` and `pressio::ops::max`:

| function | input | remarks |
|:---:|:---:|:---:|
| `min`<br>`max` | Tpetra block vector or multi-vector | requires underlying scalar type to be known integral of floating-point type |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_tpetra_vector.cc` | `ops_tpetra_block.vector_min_max` | `Tpetra::BlockVector<>` |
| `ops_tpetra_multi_vector.cc` | `tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture.multi_vector_min_max` | `Tpetra::BlockMultiVector<>` |
