### PR TITLE
ops: teuchos: revise `scale`

### DIFF
--- a/include/pressio/ops/teuchos/ops_scale.hpp
+++ b/include/pressio/ops/teuchos/ops_scale.hpp
@@ -53,7 +53,14 @@ namespace pressio{ namespace ops{
 
 template<class T, class ScalarType>
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_dense_vector_teuchos<T>::value
+  // rank-1 update common constraints
+    (::pressio::Traits<T>::rank == 1
+  || ::pressio::Traits<T>::rank == 2)
+  // TPL/container specific
+  && ::pressio::is_dense_vector_teuchos<T>::value
+  // scalar compatibility
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value)
   && std::is_convertible<ScalarType, typename ::pressio::Traits<T>::scalar_type>::value
   >
 scale(T & objectIn, ScalarType value)

--- a/include/pressio/ops/teuchos/ops_scale.hpp
+++ b/include/pressio/ops/teuchos/ops_scale.hpp
@@ -65,8 +65,14 @@ template<class T, class ScalarType>
   >
 scale(T & objectIn, ScalarType value)
 {
-  const typename ::pressio::Traits<T>::scalar_type v(value);
-  objectIn *= v;
+  using sc_t = typename ::pressio::Traits<T>::scalar_type;
+  sc_t v{value};
+  sc_t zero = ::pressio::utils::Constants<sc_t>::zero();
+  if (v == zero) {
+    ::pressio::ops::set_zero(objectIn);
+  } else {
+    objectIn *= v;
+  }
 }
 
 }} // namespace pressio::ops

--- a/tests/functional_small/ops/CMakeLists.txt
+++ b/tests/functional_small/ops/CMakeLists.txt
@@ -87,4 +87,8 @@ if(PRESSIO_ENABLE_TPL_TRILINOS)
 
  set(SRC1 ${CMAKE_CURRENT_SOURCE_DIR}/ops_epetra_level3.cc)
  add_utest_mpi(${TESTING_LEVEL}_ops_level3_epetra "${SRC1}" gTestMain_mpi 3)
+
+ # TEUCHOS
+ set(SRC1 ${CMAKE_CURRENT_SOURCE_DIR}/ops_teuchos_vector.cc)
+ add_serial_utest(${TESTING_LEVEL}_ops_vector_teuchos "${SRC1}")
 endif()

--- a/tests/functional_small/ops/ops_teuchos_vector.cc
+++ b/tests/functional_small/ops/ops_teuchos_vector.cc
@@ -17,4 +17,9 @@ TEST(ops_teuchos, vector_scale)
   for (int i=0; i<6; ++i){
     ASSERT_DOUBLE_EQ(a(i), (i + 1.) * s);
   }
+
+  // check NaN injection with zero scaling
+  a(0) = std::nan("0");
+  pressio::ops::scale(a, 0.);
+  EXPECT_DOUBLE_EQ(a(0), 0.);
 }

--- a/tests/functional_small/ops/ops_teuchos_vector.cc
+++ b/tests/functional_small/ops/ops_teuchos_vector.cc
@@ -1,0 +1,20 @@
+
+#include <gtest/gtest.h>
+#include "pressio/ops.hpp"
+
+using V_t = Teuchos::SerialDenseVector<int, double>;
+
+TEST(ops_teuchos, vector_scale)
+{
+  const int n = 6;
+  V_t a(n);
+  for (int i = 0; i < 6; ++i){
+    a(i) = i + 1.;
+  }
+
+  const double s = 3.;
+  pressio::ops::scale(a, s);
+  for (int i=0; i<6; ++i){
+    ASSERT_DOUBLE_EQ(a(i), (i + 1.) * s);
+  }
+}


### PR DESCRIPTION
refs #445

### Overloads

Teuchos overloads of `pressio::ops::scale`:

| function | input | remarks |
|:---:|:---:|:---:|
| `scale` | Teuchos vector | requires underlying scalar type to be known integral of floating-point type |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---:|:---:|
| `ops_teuchos_vector.cc` | `ops_teuchos.vector_scale` | `Teuchos::SerialDenseVector<int, double>` |
