### PR TITLE
ops: kokkos: revise `scale`

### DIFF
--- a/include/pressio/ops/kokkos/ops_scale.hpp
+++ b/include/pressio/ops/kokkos/ops_scale.hpp
@@ -53,12 +53,20 @@
 
 namespace pressio{ namespace ops{
 
-template <typename T>
+template <typename T, typename ScalarType>
 ::pressio::mpl::enable_if_t<
-    (::pressio::is_native_container_kokkos<T>::value
-  or ::pressio::is_expression_acting_on_kokkos<T>::value)
+  // rank-1 update common constraints
+    (::pressio::Traits<T>::rank == 1
+  || ::pressio::Traits<T>::rank == 2)
+  // TPL/container specific
+  && (::pressio::is_native_container_kokkos<T>::value
+  || ::pressio::is_expression_acting_on_kokkos<T>::value)
+  // scalar compatibility
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value)
+  && std::is_convertible<ScalarType, typename ::pressio::Traits<T>::scalar_type>::value
   >
-scale(const T & v, typename ::pressio::Traits<T>::scalar_type value)
+scale(const T & v, ScalarType value)
 {
   ::KokkosBlas::scal(impl::get_native(v), value, impl::get_native(v));
 }

--- a/include/pressio/ops/kokkos/ops_scale.hpp
+++ b/include/pressio/ops/kokkos/ops_scale.hpp
@@ -68,7 +68,10 @@ template <typename T, typename ScalarType>
   >
 scale(const T & v, ScalarType value)
 {
-  ::KokkosBlas::scal(impl::get_native(v), value, impl::get_native(v));
+  using sc_t = typename ::pressio::Traits<T>::scalar_type;
+  sc_t value_{value_};
+  auto vn = impl::get_native(v);
+  ::KokkosBlas::scal(vn, value_, vn);
 }
 
 }}//end namespace pressio::ops

--- a/include/pressio/ops/kokkos/ops_scale.hpp
+++ b/include/pressio/ops/kokkos/ops_scale.hpp
@@ -69,9 +69,14 @@ template <typename T, typename ScalarType>
 scale(const T & v, ScalarType value)
 {
   using sc_t = typename ::pressio::Traits<T>::scalar_type;
-  sc_t value_{value_};
-  auto vn = impl::get_native(v);
-  ::KokkosBlas::scal(vn, value_, vn);
+  const sc_t zero = ::pressio::utils::Constants<sc_t>::zero();
+  sc_t value_{value};
+  if (value_ == zero) {
+    ::pressio::ops::set_zero(v);
+  } else {
+    auto vn = impl::get_native(v);
+    ::KokkosBlas::scal(vn, value_, vn);
+  }
 }
 
 }}//end namespace pressio::ops

--- a/tests/functional_small/ops/ops_kokkos_vector.cc
+++ b/tests/functional_small/ops/ops_kokkos_vector.cc
@@ -96,6 +96,17 @@ TEST(ops_kokkos, vector_scale)
   EXPECT_DOUBLE_EQ(x_h(3), 6.);
   EXPECT_DOUBLE_EQ(x_h(4), 8.);
   EXPECT_DOUBLE_EQ(x_h(5), 10.);
+
+  // check NaN injection with zero scaling
+  ::pressio::ops::fill(x, std::nan("0"));
+  pressio::ops::scale(x, 0.);
+  x_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), x);
+  EXPECT_DOUBLE_EQ(x_h(0), 0.);
+  EXPECT_DOUBLE_EQ(x_h(1), 0.);
+  EXPECT_DOUBLE_EQ(x_h(2), 0.);
+  EXPECT_DOUBLE_EQ(x_h(3), 0.);
+  EXPECT_DOUBLE_EQ(x_h(4), 0.);
+  EXPECT_DOUBLE_EQ(x_h(5), 0.);
 }
 
 TEST(ops_kokkos, vector_fill)


### PR DESCRIPTION
refs #445

### Overloads

Kokkos overloads of `pressio::ops::scale`:

| function | input | remarks |
|:---:|:---:|:---:|
|`scale`|Kokkos view (rank-1 or rank-2)<br>or Kokkos expression| requires underlying scalar type<br> to be known integral of floating-point type|

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_kokkos_vector.cc` | `ops_kokkos.vector_scale` | `Kokkos::View<double*>` |
| `ops_kokkos_matrix.cc` | `ops_kokkos.dense_matrix_scale` | `Kokkos::View<double**>` |
| `ops_kokkos_diag.cc` | `ops_kokkos.diag_scale` | `pressio::diag( Kokkos::View<double**> )` |
| `ops_kokkos_span.cc` | `ops_kokkos.span_scale` | `pressio::span( Kokkos::View<double*> )` |
| `ops_kokkos_subspan.cc` | `ops_kokkos.subspan_scale` | `pressio::subspan( Kokkos::View<double**> )` |
