### PR TITLE
 ops: tpetra-block: `scale` implementation and tests

### DIFF
--- a/include/pressio/ops.hpp
+++ b/include/pressio/ops.hpp
@@ -146,6 +146,7 @@ template<class ...> struct matching_extents;
 #include "ops/tpetra_block/ops_extent.hpp"
 #include "ops/tpetra_block/ops_deep_copy.hpp"
 #include "ops/tpetra_block/ops_set_zero.hpp"
+#include "ops/tpetra_block/ops_scale.hpp"
 #include "ops/tpetra_block/ops_fill.hpp"
 #include "ops/tpetra_block/ops_abs.hpp"
 #include "ops/tpetra_block/ops_dot.hpp"

--- a/include/pressio/ops/tpetra_block/ops_scale.hpp
+++ b/include/pressio/ops/tpetra_block/ops_scale.hpp
@@ -53,11 +53,8 @@ namespace pressio{ namespace ops{
 
 template <typename T, class ScalarType>
 ::pressio::mpl::enable_if_t<
-  // rank-1 update common constraints
-    (::pressio::Traits<T>::rank == 1
-  || ::pressio::Traits<T>::rank == 2)
   // TPL/container specific
-  && (::pressio::is_vector_tpetra_block<T>::value
+    (::pressio::is_vector_tpetra_block<T>::value
   || ::pressio::is_multi_vector_tpetra_block<T>::value)
   // scalar compatibility
   && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value

--- a/include/pressio/ops/tpetra_block/ops_scale.hpp
+++ b/include/pressio/ops/tpetra_block/ops_scale.hpp
@@ -66,8 +66,9 @@ template <typename T, class ScalarType>
   >
 scale(T & objectIn, const ScalarType value)
 {
-  auto obj = objectIn.getMultiVectorView();
-  ::pressio::ops::scale(obj, value);
+  using sc_t = typename ::pressio::Traits<T>::scalar_type;
+  const sc_t v{value};
+  objectIn.scale(v);
 }
 
 }}//end namespace pressio::ops

--- a/include/pressio/ops/tpetra_block/ops_scale.hpp
+++ b/include/pressio/ops/tpetra_block/ops_scale.hpp
@@ -1,0 +1,74 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+// ops_scale.hpp
+//                     		  Pressio
+//                             Copyright 2019
+//    National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+//
+// Under the terms of Contract DE-NA0003525 with NTESS, the
+// U.S. Government retains certain rights in this software.
+//
+// Pressio is licensed under BSD-3-Clause terms of use:
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Francesco Rizzi (fnrizzi@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef OPS_TPETRA_BLOCK_OPS_SCALE_HPP_
+#define OPS_TPETRA_BLOCK_OPS_SCALE_HPP_
+
+namespace pressio{ namespace ops{
+
+template <typename T, class ScalarType>
+::pressio::mpl::enable_if_t<
+  // rank-1 update common constraints
+    (::pressio::Traits<T>::rank == 1
+  || ::pressio::Traits<T>::rank == 2)
+  // TPL/container specific
+  && (::pressio::is_vector_tpetra_block<T>::value
+  || ::pressio::is_multi_vector_tpetra_block<T>::value)
+  // scalar compatibility
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value)
+  && std::is_convertible<ScalarType, typename ::pressio::Traits<T>::scalar_type>::value
+  >
+scale(T & objectIn, const ScalarType value)
+{
+  auto obj = objectIn.getMultiVectorView();
+  ::pressio::ops::scale(obj, value);
+}
+
+}}//end namespace pressio::ops
+#endif  // OPS_TPETRA_BLOCK_OPS_SCALE_HPP_

--- a/tests/functional_small/ops/ops_tpetra_block_multi_vector.cc
+++ b/tests/functional_small/ops/ops_tpetra_block_multi_vector.cc
@@ -48,6 +48,18 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture, multi_vector_setz
   }
 }
 
+TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture, multi_vector_scale)
+{
+  myMv_->putScalar(2.);
+  ::pressio::ops::scale(*myMv_, 3.);
+  auto myMv_h = myMv_->getMultiVectorView().getLocalViewHost(Tpetra::Access::ReadOnly);
+  for (int i = 0; i < localSize_ * blockSize_; ++i){
+    for (int j = 0; j < numVecs_; ++j){
+      EXPECT_DOUBLE_EQ(myMv_h(i, j), 6.);
+    }
+  }
+}
+
 TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture, multi_vector_fill)
 {
   ::pressio::ops::fill(*myMv_, 55.);

--- a/tests/functional_small/ops/ops_tpetra_block_vector.cc
+++ b/tests/functional_small/ops/ops_tpetra_block_vector.cc
@@ -54,6 +54,16 @@ TEST_F(ops_tpetra_block, vector_setzero)
   }
 }
 
+TEST_F(ops_tpetra_block, vector_scale)
+{
+  myVector_->putScalar(2.);
+  ::pressio::ops::scale(*myVector_, 3.);
+  auto x_h2 = myVector_->getVectorView().getLocalViewHost(Tpetra::Access::ReadOnly);
+  for (int i = 0; i < localSize_ * blockSize_; ++i){
+    EXPECT_DOUBLE_EQ(x_h2(i, 0), 6.);
+  }
+}
+
 TEST_F(ops_tpetra_block, vector_fill)
 {
   pressio::ops::fill(*myVector_, 55.);

--- a/tests/functional_small/ops/ops_tpetra_block_vector.cc
+++ b/tests/functional_small/ops/ops_tpetra_block_vector.cc
@@ -62,6 +62,14 @@ TEST_F(ops_tpetra_block, vector_scale)
   for (int i = 0; i < localSize_ * blockSize_; ++i){
     EXPECT_DOUBLE_EQ(x_h2(i, 0), 6.);
   }
+
+  // NaN injection
+  myVector_->putScalar(std::nan("0"));
+  pressio::ops::scale(*myVector_, 0.);
+  x_h2 = myVector_->getVectorView().getLocalViewHost(Tpetra::Access::ReadOnly);
+  for (int i = 0; i < localSize_ * blockSize_; ++i){
+    EXPECT_DOUBLE_EQ(x_h2(i, 0), 0.);
+  }
 }
 
 TEST_F(ops_tpetra_block, vector_fill)


### PR DESCRIPTION
refs #445

### Overloads

Block Tpetra overloads of `pressio::ops::scale`:

| function | input | remarks |
|:---:|:---:|:---:|
| `scale` | Tpetra block vector or block multi-vector | requires underlying scalar type to be known integral of floating-point type |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_tpetra_block_vector.cc` | `ops_tpetra_block.vector_scale` | `Tpetra::BlockVector<>` |
| `ops_tpetra_block_multi_vector.cc` | `tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture.multi_vector_scale` | `Tpetra::BlockMultiVector<>` |
