### PR TITLE
ops: clean `scale` guards

### DIFF
--- a/include/pressio/ops/eigen/ops_level2.hpp
+++ b/include/pressio/ops/eigen/ops_level2.hpp
@@ -107,8 +107,7 @@ product(::pressio::nontranspose /*unused*/,
   const auto & A_n = impl::get_native(A);
   const auto & x_n = impl::get_native(x);
   if (alpha_ == zero) {
-    if (has_beta) { ::pressio::ops::scale(y_n, beta_); }
-    else { ::pressio::ops::set_zero(y_n); }
+    ::pressio::ops::scale(y_n, beta_);
   } else {
     if (has_beta) { y_n = beta_ * y_n + alpha_ * A_n * x_n; }
     else { y_n = alpha_ * A_n * x_n; }
@@ -201,8 +200,7 @@ product(::pressio::transpose /*unused*/,
   const auto & A_n = impl::get_native(A);
   const auto & x_n = impl::get_native(x);
   if (alpha_ == zero) {
-    if (has_beta) { ::pressio::ops::scale(y_n, beta_); }
-    else { ::pressio::ops::set_zero(y_n); }
+    ::pressio::ops::scale(y_n, beta_);
   } else {
     if (has_beta) { y_n = beta_ * y_n + alpha_ * A_n.transpose() * x_n; }
     else { y_n = alpha_ * A_n.transpose() * x_n; }

--- a/include/pressio/ops/eigen/ops_rank1_update.hpp
+++ b/include/pressio/ops/eigen/ops_rank1_update.hpp
@@ -89,11 +89,7 @@ update(T & v,         const a_Type & a,
   sc_t b_{b};
 
   if (b_ == zero) {
-    if (a_ == zero) {
-      ::pressio::ops::set_zero(v);
-    } else {
-      ::pressio::ops::scale(v, a_);
-    }
+    ::pressio::ops::scale(v, a_);
     return;
   }
 

--- a/include/pressio/ops/eigen/ops_rank2_update.hpp
+++ b/include/pressio/ops/eigen/ops_rank2_update.hpp
@@ -90,11 +90,7 @@ update(T & M,         const alpha_t & a,
 
   const auto zero = ::pressio::utils::Constants<sc_t>::zero();
   if (b_ == zero) {
-    if (a_ == zero) {
-      ::pressio::ops::set_zero(M);
-    } else {
-      ::pressio::ops::scale(M, a_);
-    }
+    ::pressio::ops::scale(M, a_);
     return;
   }
 

--- a/include/pressio/ops/epetra/ops_level2.hpp
+++ b/include/pressio/ops/epetra/ops_level2.hpp
@@ -66,11 +66,7 @@ void _product_epetra_mv_sharedmem_vec(const scalar_type alpha,
 				      Epetra_Vector & y)
 {
   constexpr auto zero = pressio::utils::Constants<scalar_type>::zero();
-  if (beta == zero) {
-    ::pressio::ops::set_zero(y);
-  } else {
-    y.Scale(beta); // TODO: implement ::pressio::ops::scale( Epetra_Vector )
-  }
+  ::pressio::ops::scale(y, beta);
   if (alpha == zero) {
     return;
   }

--- a/include/pressio/ops/epetra/ops_multi_vector_update.hpp
+++ b/include/pressio/ops/epetra/ops_multi_vector_update.hpp
@@ -80,9 +80,6 @@ update(T & mv, const alpha_t &a,
   const scalar_t b_{b};
 
   constexpr auto zero = ::pressio::utils::Constants<scalar_t>::zero();
-  if (a_ == zero) {
-    ::pressio::ops::set_zero(mv);
-  }
   if (b_ == zero) {
     ::pressio::ops::scale(mv, a_);
   } else {

--- a/include/pressio/ops/epetra/ops_rank1_update.hpp
+++ b/include/pressio/ops/epetra/ops_rank1_update.hpp
@@ -81,11 +81,7 @@ update(T & v,         const a_Type a,
   scalar_t b_{b};
 
   if (b_ == zero) {
-    if (a_ == zero) {
-      ::pressio::ops::set_zero(v);
-    } else {
-      ::pressio::ops::scale(v, a_);
-    }
+    ::pressio::ops::scale(v, a_);
     return;
   }
 

--- a/include/pressio/ops/kokkos/ops_level2.hpp
+++ b/include/pressio/ops/kokkos/ops_level2.hpp
@@ -105,11 +105,7 @@ product(::pressio::nontranspose /*unused*/,
   // so we can use it here
   const auto zero = Kokkos::Details::ArithTraits<sc_t>::zero();
   if (static_cast<sc_t>(alpha_) == zero) {
-    if (beta_ == zero) {
-      ::pressio::ops::set_zero(y);
-    } else {
-      ::pressio::ops::scale(y, beta_);
-    }
+    ::pressio::ops::scale(y, beta_);
     return;
   }
 
@@ -166,11 +162,7 @@ product(::pressio::transpose /*unused*/,
   // so we can use it here
   const auto zero = Kokkos::Details::ArithTraits<sc_t>::zero();
   if (static_cast<sc_t>(alpha_) == zero) {
-    if (beta_ == zero) {
-      ::pressio::ops::set_zero(y);
-    } else {
-      ::pressio::ops::scale(y, beta_);
-    }
+    ::pressio::ops::scale(y, beta_);
     return;
   }
 

--- a/include/pressio/ops/tpetra/ops_level2.hpp
+++ b/include/pressio/ops/tpetra/ops_level2.hpp
@@ -344,12 +344,7 @@ product(::pressio::nontranspose /*unused*/,
   assert( ::pressio::ops::extent(x, 0) == ::pressio::ops::extent(A_h, 1) );
 
   const auto zero = ::pressio::utils::Constants<beta_t>::zero();
-  if (beta == zero) {
-    ::pressio::ops::set_zero(y_h);
-  }
-  else {
-    ::pressio::ops::scale(y_h, beta);
-  }
+  ::pressio::ops::scale(y_h, beta);
   if (alpha == zero) {
     return;
   }


### PR DESCRIPTION
We no longer need anti-NaN-injection guards around `pressio::ops::scale()`, because it calls `pressio::ops::set_zero()` internally, if needed.

refs #445