### PR TITLE
ops: eigen: revise overload constraints of norms

### DIFF
--- a/include/pressio/ops/eigen/ops_norms.hpp
+++ b/include/pressio/ops/eigen/ops_norms.hpp
@@ -53,9 +53,14 @@ namespace pressio{ namespace ops{
 
 template <typename T>
 ::pressio::mpl::enable_if_t<
-  (::pressio::is_vector_eigen<T>::value or
-  ::pressio::is_expression_acting_on_eigen<T>::value) and
-  ::pressio::Traits<T>::rank == 1,
+  // norm-1 common constraints
+  ::pressio::Traits<T>::rank == 1
+  // TPL/container specific
+  && (::pressio::is_vector_eigen<T>::value
+   || ::pressio::is_expression_acting_on_eigen<T>::value)
+  // scalar compatibility
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value),
   decltype( impl::get_native(std::declval<const T>()).template lpNorm<1>() )
   >
 norm1(const T & a)
@@ -65,9 +70,14 @@ norm1(const T & a)
 
 template <typename T>
 ::pressio::mpl::enable_if_t<
-  (::pressio::is_vector_eigen<T>::value
-  or ::pressio::is_expression_acting_on_eigen<T>::value) and
-  ::pressio::Traits<T>::rank == 1,
+  // norm-2 common constraints
+  ::pressio::Traits<T>::rank == 1
+  // TPL/container specific
+  && (::pressio::is_vector_eigen<T>::value
+   || ::pressio::is_expression_acting_on_eigen<T>::value)
+  // scalar compatibility
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value),
   decltype( impl::get_native(std::declval<const T>()).template lpNorm<2>() )
   >
 norm2(const T & a)


### PR DESCRIPTION
refs #450

### Overloads

Eigen overloads of norms:

| function | input | remarks |
|:---:|:---:|:---:|
| `norm1`<br>`norm2` | Eigen vector or rank-1 expression | requires underlying scalar type to be known integral of floating-point type |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_eigen_vector.cc` | `ops_eigen.vector_norm1`<br>`ops_eigen.vector_norm2` | `Eigen::VectorXd` |
| `ops_eigen_diag.cc` | `ops_eigen.diag_norms` | `pressio::diag( Eigen::MatrixXd )` |
| `ops_eigen_span.cc` | `ops_eigen.span_norms` | `pressio::span( Eigen::VectorXd )` |
