### PR TITLE
 ops: kokkos: revise overload constraints of norms

### DIFF
--- a/include/pressio/ops/kokkos/ops_norms_vector.hpp
+++ b/include/pressio/ops/kokkos/ops_norms_vector.hpp
@@ -56,9 +56,14 @@ namespace pressio{ namespace ops{
 
 template <typename T>
 ::pressio::mpl::enable_if_t<
-    (::pressio::is_native_container_kokkos<T>::value
-  or ::pressio::is_expression_acting_on_kokkos<T>::value)
-  and ::pressio::Traits<T>::rank == 1,
+  // norm-1 common constraints
+  ::pressio::Traits<T>::rank == 1
+  // TPL/container specific
+  && (::pressio::is_native_container_kokkos<T>::value
+   || ::pressio::is_expression_acting_on_kokkos<T>::value)
+  // scalar compatibility
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value),
   typename ::pressio::Traits<T>::scalar_type
 >
 norm1(const T & a)
@@ -68,9 +73,14 @@ norm1(const T & a)
 
 template <typename T>
 ::pressio::mpl::enable_if_t<
-    (::pressio::is_native_container_kokkos<T>::value
-  or ::pressio::is_expression_acting_on_kokkos<T>::value)
-  and ::pressio::Traits<T>::rank == 1,
+  // norm-2 common constraints
+  ::pressio::Traits<T>::rank == 1
+  // TPL/container specific
+  && (::pressio::is_native_container_kokkos<T>::value
+   || ::pressio::is_expression_acting_on_kokkos<T>::value)
+  // scalar compatibility
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value),
   typename ::pressio::Traits<T>::scalar_type
 >
 norm2(const T & a)


### PR DESCRIPTION
refs #450

### Overloads

Kokkos overloads of norms:

| function | input | remarks |
|:---:|:---:|:---:|
| `norm1`<br>`norm2` | rank-1 Kokkos view or expression | requires underlying scalar type to be known integral of floating-point type|

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_kokkos_vector.cc` | `ops_kokkos.vector_norm1`<br>`ops_kokkos.vector_norm2` | `Kokkos::View<double*>` |
| `ops_kokkos_diag.cc` | `ops_kokkos.diag_norms` | `pressio::diag( Kokkos::View<double**> )` |
| `ops_kokkos_span.cc` | `ops_kokkos.span_norms` | `pressio::span( Kokkos::View<double*> )` |
