### PR TITLE
ops: kokkos: revise `dot`

### DIFF
--- a/tests/functional_small/ops/ops_kokkos_vector.cc
+++ b/tests/functional_small/ops/ops_kokkos_vector.cc
@@ -176,6 +176,9 @@ TEST(ops_kokkos, vector_dot)
   Kokkos::View<double*> b("b", 6);
   pressio::ops::fill(b, 2.);
   ASSERT_DOUBLE_EQ(pressio::ops::dot(a,b), 12.);
+  double result;
+  pressio::ops::dot(a,b,result);
+  ASSERT_DOUBLE_EQ(result,12.);
 }
 
 TEST(ops_kokkos, vector_pow)


### PR DESCRIPTION
refs #524

### Overloads

Kokkos `dot` overloads:

| function | input | remarks |
|:---:|:---:|:---:|
| `void dot(a, b, scalar)`<br>`scalar dot(a, b)` | Kokkos rank-1 views or expressions | requires underlying scalar type<br>to be known integral of floating-point type |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_kokkos_vector.cc` | `ops_kokkos.vector_dot` | `Kokkos::View<double*>` |
| `ops_kokkos_diag.cc` | `ops_kokkos.diag_dot_diag`<br>`ops_kokkos.diag_dot_vector` | `pressio::diag( Kokkos::View<double**> )` |
| `ops_kokkos_span.cc` | `ops_kokkos.span_dot` | `pressio::span( Kokkos::View<double*> )` |
