### PR TITLE
ops: tpetra: revise `dot` overload constraints

### DIFF
--- a/include/pressio/ops/tpetra/ops_dot.hpp
+++ b/include/pressio/ops/tpetra/ops_dot.hpp
@@ -53,8 +53,16 @@ namespace pressio{ namespace ops{
 
 template <typename T1, typename T2>
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_vector_tpetra<T1>::value and
-  ::pressio::is_vector_tpetra<T2>::value,
+  // dot common constraints
+     ::pressio::Traits<T1>::rank == 1
+  && ::pressio::Traits<T2>::rank == 1
+  // TPL/container specific
+  && ::pressio::is_vector_tpetra<T1>::value
+  && ::pressio::is_vector_tpetra<T2>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<T1, T2>::value
+  && (std::is_floating_point<typename ::pressio::Traits<T1>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T1>::scalar_type>::value),
   decltype( std::declval<const T1>().dot(std::declval<const T2>()) )
   >
 dot(const T1 & a, const T2 & b){
@@ -65,8 +73,16 @@ dot(const T1 & a, const T2 & b){
 
 template <typename T1, typename T2, class DotResult>
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_vector_tpetra<T1>::value
+  // dot common constraints
+     ::pressio::Traits<T1>::rank == 1
+  && ::pressio::Traits<T2>::rank == 1
+  // TPL/container specific
+  && ::pressio::is_vector_tpetra<T1>::value
   && ::pressio::is_vector_tpetra<T2>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<T1, T2>::value
+  && (std::is_floating_point<typename ::pressio::Traits<T1>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T1>::scalar_type>::value)
   && std::is_convertible<
     decltype( dot(std::declval<const T1>(), std::declval<const T2>()) ),
     DotResult

--- a/include/pressio/ops/tpetra/ops_dot.hpp
+++ b/include/pressio/ops/tpetra/ops_dot.hpp
@@ -53,11 +53,8 @@ namespace pressio{ namespace ops{
 
 template <typename T1, typename T2>
 ::pressio::mpl::enable_if_t<
-  // dot common constraints
-     ::pressio::Traits<T1>::rank == 1
-  && ::pressio::Traits<T2>::rank == 1
   // TPL/container specific
-  && ::pressio::is_vector_tpetra<T1>::value
+     ::pressio::is_vector_tpetra<T1>::value
   && ::pressio::is_vector_tpetra<T2>::value
   // scalar compatibility
   && ::pressio::all_have_traits_and_same_scalar<T1, T2>::value
@@ -73,11 +70,8 @@ dot(const T1 & a, const T2 & b){
 
 template <typename T1, typename T2, class DotResult>
 ::pressio::mpl::enable_if_t<
-  // dot common constraints
-     ::pressio::Traits<T1>::rank == 1
-  && ::pressio::Traits<T2>::rank == 1
   // TPL/container specific
-  && ::pressio::is_vector_tpetra<T1>::value
+     ::pressio::is_vector_tpetra<T1>::value
   && ::pressio::is_vector_tpetra<T2>::value
   // scalar compatibility
   && ::pressio::all_have_traits_and_same_scalar<T1, T2>::value


### PR DESCRIPTION
refs #524

### Overloads

Tpetra `dot` overloads:

| function | input | remarks |
|:---:|:---:|:---:|
| `void dot(a, b, scalar)`<br>`scalar dot(a, b)` | Tpetra vectors | requires underlying scalar type<br>to be known integral of floating-point type |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_tpetra_vector.cc` | `ops_tpetra.vector_dot` | `Tpetra::Vector<>` |
