### PR TITLE
ops: tpetra-block: revise `dot` overload constraints

### DIFF
--- a/include/pressio/ops/tpetra_block/ops_dot.hpp
+++ b/include/pressio/ops/tpetra_block/ops_dot.hpp
@@ -53,9 +53,20 @@ namespace pressio{ namespace ops{
 
 template <typename T1, typename T2>
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_vector_tpetra_block<T1>::value and
-  ::pressio::is_vector_tpetra_block<T2>::value,
-  typename ::pressio::Traits<T1>::scalar_type
+  // dot common constraints
+     ::pressio::Traits<T1>::rank == 1
+  && ::pressio::Traits<T2>::rank == 1
+  // TPL/container specific
+  && ::pressio::is_vector_tpetra_block<T1>::value
+  && ::pressio::is_vector_tpetra_block<T2>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<T1, T2>::value
+  && (std::is_floating_point<typename ::pressio::Traits<T1>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T1>::scalar_type>::value),
+  decltype(
+    std::declval<T1>().getVectorView().dot(
+      std::declval<T2>().getVectorView())
+    )
   >
 dot(const T1 & a, const T2 & b)
 {
@@ -70,8 +81,20 @@ dot(const T1 & a, const T2 & b)
 
 template <typename T1, typename T2, class DotResult>
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_vector_tpetra_block<T1>::value
+  // dot common constraints
+     ::pressio::Traits<T1>::rank == 1
+  && ::pressio::Traits<T2>::rank == 1
+  // TPL/container specific
+  && ::pressio::is_vector_tpetra_block<T1>::value
   && ::pressio::is_vector_tpetra_block<T2>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<T1, T2>::value
+  && (std::is_floating_point<typename ::pressio::Traits<T1>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T1>::scalar_type>::value)
+  && std::is_convertible<
+    decltype( dot(std::declval<const T1&>(), std::declval<const T2&>()) ),
+    DotResult
+    >::value
   >
 dot(const T1 & a, const T2 & b, DotResult & result)
 {

--- a/include/pressio/ops/tpetra_block/ops_dot.hpp
+++ b/include/pressio/ops/tpetra_block/ops_dot.hpp
@@ -53,11 +53,8 @@ namespace pressio{ namespace ops{
 
 template <typename T1, typename T2>
 ::pressio::mpl::enable_if_t<
-  // dot common constraints
-     ::pressio::Traits<T1>::rank == 1
-  && ::pressio::Traits<T2>::rank == 1
   // TPL/container specific
-  && ::pressio::is_vector_tpetra_block<T1>::value
+     ::pressio::is_vector_tpetra_block<T1>::value
   && ::pressio::is_vector_tpetra_block<T2>::value
   // scalar compatibility
   && ::pressio::all_have_traits_and_same_scalar<T1, T2>::value
@@ -81,11 +78,8 @@ dot(const T1 & a, const T2 & b)
 
 template <typename T1, typename T2, class DotResult>
 ::pressio::mpl::enable_if_t<
-  // dot common constraints
-     ::pressio::Traits<T1>::rank == 1
-  && ::pressio::Traits<T2>::rank == 1
   // TPL/container specific
-  && ::pressio::is_vector_tpetra_block<T1>::value
+     ::pressio::is_vector_tpetra_block<T1>::value
   && ::pressio::is_vector_tpetra_block<T2>::value
   // scalar compatibility
   && ::pressio::all_have_traits_and_same_scalar<T1, T2>::value


### PR DESCRIPTION
refs #524

### Overloads

Block Tpetra `dot` overloads:

| function | input | remarks |
|:---:|:---:|:---:|
| `void dot(a, b, scalar)`<br>`scalar dot(a, b)` | Tpetra block vectors | requires underlying scalar type<br>to be known integral of floating-point type |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_tpetra_block_vector.cc` | `ops_tpetra_block.vector_dot` | `Tpetra::BlockVector<>` |
