### PR TITLE
ops: epetra: revise `clone` overload constraints

### DIFF
--- a/include/pressio/ops/epetra/ops_clone.hpp
+++ b/include/pressio/ops/epetra/ops_clone.hpp
@@ -54,8 +54,13 @@ namespace pressio{ namespace ops{
 
 template <typename T>
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_vector_epetra<T>::value or
-  ::pressio::is_multi_vector_epetra<T>::value, T
+  // common clone constraints
+    (::pressio::Traits<T>::rank == 1
+  || ::pressio::Traits<T>::rank == 2)
+  // TPL/container specific
+  && (::pressio::is_vector_epetra<T>::value
+   || ::pressio::is_multi_vector_epetra<T>::value),
+  T
   >
 clone(const T & clonable)
 {


### PR DESCRIPTION
refs #517

### Overloads

Epetra `clone` overloads:

| function | input `T` |
|:---:|:---:|
| `clone( T )` | Epetra vector or multi-vector |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_epetra_vector.cc` | `ops_epetra.vector_clone` | `Epetra_Vector` |
| `ops_epetra_multi_vector.cc` | `epetraMultiVectorGlobSize15Fixture.multi_vector_clone` | `Epetra_MultiVector` |
