### PR TITLE
ops: tpetra: revise `clone` overload constraints

### DIFF
--- a/include/pressio/ops/tpetra/ops_clone.hpp
+++ b/include/pressio/ops/tpetra/ops_clone.hpp
@@ -53,8 +53,13 @@ namespace pressio{ namespace ops{
 
 template <typename T>
 ::pressio::mpl::enable_if_t<
-	::pressio::is_vector_tpetra<T>::value or 
-  ::pressio::is_multi_vector_tpetra<T>::value, T
+  // common clone constraints
+    (::pressio::Traits<T>::rank == 1
+  || ::pressio::Traits<T>::rank == 2)
+  // TPL/container specific
+  && (::pressio::is_vector_tpetra<T>::value
+   || ::pressio::is_multi_vector_tpetra<T>::value),
+  T
   >
 clone(const T & clonable)
 {


### PR DESCRIPTION
refs #517

### Overloads

Tpetra `clone` overloads:

| function | input `T` |
|:---:|:---:|
| `clone( T )` | Tpetra vector or multi-vector |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_tpetra_vector.cc` | `ops_tpetra.vector_clone` | `Tpetra::Vector<>` |
| `ops_tpetra_multi_vector.cc` | `tpetraMultiVectorGlobSize15Fixture.multi_vector_clone` | `Tpetra::MultiVector<>` |
