### PR TITLE
ops: tpetra-block: revise `clone` overload constraints

### DIFF
--- a/include/pressio/ops/tpetra_block/ops_clone.hpp
+++ b/include/pressio/ops/tpetra_block/ops_clone.hpp
@@ -53,8 +53,13 @@ namespace pressio{ namespace ops{
 
 template <typename T>
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_vector_tpetra_block<T>::value or
-  ::pressio::is_multi_vector_tpetra_block<T>::value, T
+  // common clone constraints
+    (::pressio::Traits<T>::rank == 1
+  || ::pressio::Traits<T>::rank == 2)
+  // TPL/container specific
+  && (::pressio::is_vector_tpetra_block<T>::value
+   || ::pressio::is_multi_vector_tpetra_block<T>::value),
+  T
   >
 clone(const T & clonable)
 {


### PR DESCRIPTION
refs #517

### Overloads

Block Tpetra `clone` overloads:

| function | input `T` |
|:---:|:---:|
| `clone( T )` | Tpetra block vector or block multi-vector |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_tpetra_block_vector.cc` | `ops_tpetra_block.vector_clone` | `Tpetra::BlockVector<>` |
| `ops_tpetra_block_multi_vector.cc` | `tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture.multi_vector_clone` | `Tpetra::BlockMultiVector<>` |
