### PR TITLE
ops: teuchos: add `clone` implementation and unit test

### DIFF
--- a/include/pressio/ops.hpp
+++ b/include/pressio/ops.hpp
@@ -116,6 +116,7 @@ template<class ...> struct matching_extents;
 #ifdef PRESSIO_ENABLE_TPL_TRILINOS
 // Teuchos
 #include "ops/teuchos/ops_extent.hpp"
+#include "ops/teuchos/ops_clone.hpp"
 #include "ops/teuchos/ops_set_zero.hpp"
 #include "ops/teuchos/ops_scale.hpp"
 #include "ops/teuchos/ops_fill.hpp"

--- a/include/pressio/ops/teuchos/ops_clone.hpp
+++ b/include/pressio/ops/teuchos/ops_clone.hpp
@@ -1,0 +1,68 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+// ops_clone.hpp
+//                     		  Pressio
+//                             Copyright 2019
+//    National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+//
+// Under the terms of Contract DE-NA0003525 with NTESS, the
+// U.S. Government retains certain rights in this software.
+//
+// Pressio is licensed under BSD-3-Clause terms of use:
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Francesco Rizzi (fnrizzi@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef OPS_TEUCHOS_OPS_CLONE_HPP_
+#define OPS_TEUCHOS_OPS_CLONE_HPP_
+
+namespace pressio{ namespace ops{
+
+template <typename T>
+::pressio::mpl::enable_if_t<
+  // common clone constraints
+  ::pressio::Traits<T>::rank == 1
+  // TPL/container specific
+  && ::pressio::is_dense_vector_teuchos<T>::value,
+  T
+  >
+clone(const T & clonable)
+{
+  return T(Teuchos::Copy, clonable);
+}
+
+}}
+#endif  // OPS_TEUCHOS_OPS_CLONE_HPP_

--- a/tests/functional_small/ops/ops_teuchos_vector.cc
+++ b/tests/functional_small/ops/ops_teuchos_vector.cc
@@ -4,6 +4,25 @@
 
 using V_t = Teuchos::SerialDenseVector<int, double>;
 
+TEST(ops_teuchos, vector_clone)
+{
+  const int n = 6;
+  V_t a(n);
+  for (int i = 0; i < 6; ++i){
+    a(i) = i + 1.;
+  }
+
+  auto b = pressio::ops::clone(a);
+  ASSERT_EQ(::pressio::ops::extent(b, 0), 6);
+  for (int i = 0; i < 6; ++i){
+    ASSERT_DOUBLE_EQ(b(i), a(i));
+  }
+
+  // check if b.data() == a.data()
+  a(0) = 55.;
+  ASSERT_DOUBLE_EQ(b(0), 1.);
+}
+
 TEST(ops_teuchos, vector_scale)
 {
   const int n = 6;


### PR DESCRIPTION
refs #517

### Overloads

Teuchos `clone` overloads:

| function | input `T` |
|:---:|:---:|
| `clone( T )` | `Teuchos::SerialDenseVector<OrdinalType, ScalarType>` |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_teuchos_vector.cc` | `ops_teuchos.vector_clone` | `Teuchos::SerialDenseVector<int, double>` |