### PR TITLE
ops: teuchos: add norms implementation and unit test

### DIFF
--- a/include/pressio/ops.hpp
+++ b/include/pressio/ops.hpp
@@ -119,6 +119,7 @@ template<class ...> struct matching_extents;
 #include "ops/teuchos/ops_set_zero.hpp"
 #include "ops/teuchos/ops_scale.hpp"
 #include "ops/teuchos/ops_fill.hpp"
+#include "ops/teuchos/ops_norms.hpp"
 #include "ops/teuchos/ops_level2.hpp"
 
 // Tpetra

--- a/include/pressio/ops/teuchos/ops_norms.hpp
+++ b/include/pressio/ops/teuchos/ops_norms.hpp
@@ -1,0 +1,87 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+// ops_norms.hpp
+//                     		  Pressio
+//                             Copyright 2019
+//    National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+//
+// Under the terms of Contract DE-NA0003525 with NTESS, the
+// U.S. Government retains certain rights in this software.
+//
+// Pressio is licensed under BSD-3-Clause terms of use:
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Francesco Rizzi (fnrizzi@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef OPS_TEUCHOS_OPS_NORMS_VECTOR_HPP_
+#define OPS_TEUCHOS_OPS_NORMS_VECTOR_HPP_
+
+namespace pressio{ namespace ops{
+
+template <typename T>
+::pressio::mpl::enable_if_t<
+  // norm-2 common constraints
+  ::pressio::Traits<T>::rank == 1
+  // TPL/container specific
+  && ::pressio::is_dense_vector_teuchos<T>::value
+  // scalar compatibility
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value),
+  typename ::pressio::Traits<T>::scalar_type
+>
+norm1(const T & v)
+{
+  return v.normOne();
+}
+
+template <typename T>
+::pressio::mpl::enable_if_t<
+  // norm-2 common constraints
+  ::pressio::Traits<T>::rank == 1
+  // TPL/container specific
+  && ::pressio::is_dense_vector_teuchos<T>::value
+  // scalar compatibility
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value),
+  typename ::pressio::Traits<T>::scalar_type
+>
+norm2(const T & v)
+{
+  return v.normFrobenius();
+}
+
+}}//end namespace pressio::ops
+#endif  // OPS_TEUCHOS_OPS_NORMS_VECTOR_HPP_

--- a/tests/functional_small/ops/ops_teuchos_vector.cc
+++ b/tests/functional_small/ops/ops_teuchos_vector.cc
@@ -23,3 +23,13 @@ TEST(ops_teuchos, vector_scale)
   pressio::ops::scale(a, 0.);
   EXPECT_DOUBLE_EQ(a(0), 0.);
 }
+
+TEST(ops_teuchos, vector_norms)
+{
+  const int n = 2;
+  V_t a(n);
+  a(0) = -3.;
+  a(1) = -4.;
+  ASSERT_DOUBLE_EQ(pressio::ops::norm1(a), std::abs(-3) + std::abs(-4));
+  ASSERT_DOUBLE_EQ(pressio::ops::norm2(a), std::sqrt( 9. + 16. ));
+}


### PR DESCRIPTION
refs #450

### Overloads

Teuchos overloads of norms:

| function | input | remarks |
|:---:|:---:|:---:|
| `norm1`<br>`norm2` | `Teuchos::SerialDenseVector<OrdinalType, ScalarType>` | requires underlying scalar type<br> to be known integral of floating-point type |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_teuchos_vector.cc` | `ops_teuchos.vector_norms` | `Teuchos::SerialDenseVector<int, double>` |

