### PR TITLE
ops: eigen: revise `deep_copy`

### DIFF
--- a/include/pressio/ops/eigen/ops_deep_copy.hpp
+++ b/include/pressio/ops/eigen/ops_deep_copy.hpp
@@ -56,13 +56,18 @@ template<typename T1, typename T2>
   // common deep_copy constraints
   ::pressio::Traits<T1>::rank == ::pressio::Traits<T2>::rank
   // TPL/container specific
-  && ::pressio::is_native_container_eigen<T1>::value
-  && ::pressio::is_native_container_eigen<T2>::value
+  && (::pressio::is_native_container_eigen<T1>::value
+   || ::pressio::is_expression_acting_on_eigen<T1>::value)
+  && (::pressio::is_native_container_eigen<T2>::value
+   || ::pressio::is_expression_acting_on_eigen<T2>::value)
   >
 deep_copy(T2 & dest, const T1 & src)
 {
   assert((matching_extents<T2, T1>::compare(dest, src)));
-  dest = src;
+
+  const auto src_n = impl::get_native(src);
+  auto && dest_n = impl::get_native(dest);
+  dest_n = src_n;
 }
 
 }}//end namespace pressio::ops

--- a/include/pressio/ops/eigen/ops_deep_copy.hpp
+++ b/include/pressio/ops/eigen/ops_deep_copy.hpp
@@ -61,7 +61,7 @@ template<typename T1, typename T2>
   >
 deep_copy(T2 & dest, const T1 & src)
 {
-  assert((matching_extents<T1, T2>::compare(dest, src)));
+  assert((matching_extents<T2, T1>::compare(dest, src)));
   dest = src;
 }
 

--- a/include/pressio/ops/eigen/ops_deep_copy.hpp
+++ b/include/pressio/ops/eigen/ops_deep_copy.hpp
@@ -52,10 +52,12 @@
 namespace pressio{ namespace ops{
 
 template<typename T1, typename T2>
-std::enable_if_t<
-     ::pressio::is_native_container_eigen<T1>::value
+::pressio::mpl::enable_if_t<
+  // common deep_copy constraints
+  ::pressio::Traits<T1>::rank == ::pressio::Traits<T2>::rank
+  // TPL/container specific
+  && ::pressio::is_native_container_eigen<T1>::value
   && ::pressio::is_native_container_eigen<T2>::value
-  && ::pressio::Traits<T1>::rank == ::pressio::Traits<T2>::rank
   >
 deep_copy(T2 & dest, const T1 & src)
 {

--- a/include/pressio/ops/eigen/ops_deep_copy.hpp
+++ b/include/pressio/ops/eigen/ops_deep_copy.hpp
@@ -52,7 +52,7 @@
 namespace pressio{ namespace ops{
 
 template<typename T1, typename T2>
-::pressio::mpl::enable_if_t<
+std::enable_if_t<
   // common deep_copy constraints
   ::pressio::Traits<T1>::rank == ::pressio::Traits<T2>::rank
   // TPL/container specific

--- a/include/pressio/ops/eigen/ops_deep_copy.hpp
+++ b/include/pressio/ops/eigen/ops_deep_copy.hpp
@@ -65,7 +65,7 @@ deep_copy(T2 & dest, const T1 & src)
 {
   assert((matching_extents<T2, T1>::compare(dest, src)));
 
-  const auto src_n = impl::get_native(src);
+  auto && src_n = impl::get_native(src);
   auto && dest_n = impl::get_native(dest);
   dest_n = src_n;
 }

--- a/tests/functional_small/ops/ops_eigen_diag.cc
+++ b/tests/functional_small/ops/ops_eigen_diag.cc
@@ -148,7 +148,30 @@ TEST(ops_eigen_diag, fill)
   ASSERT_DOUBLE_EQ(a(4,4),44.);
 }
 
-TEST(ops_eigen_diag, min_max)
+TEST(ops_eigen, diag_deep_copy)
+{
+  using T = Eigen::MatrixXd;
+  T a(6, 6);
+  auto exp = pressio::diag(a);
+  ::pressio::ops::fill(exp, 44.);
+
+  // copy to native vector
+  Eigen::VectorXd b(6);
+  pressio::ops::deep_copy(b, exp);
+  for (int i = 0; i < 6; ++i){
+    ASSERT_DOUBLE_EQ(b(i), 44.);
+  }
+
+  // copy to expression
+  T a2(6, 6);
+  auto exp2 = pressio::diag(a2);
+  pressio::ops::deep_copy(exp2, exp);
+  for (int i = 0; i < 6; ++i){
+    ASSERT_DOUBLE_EQ(exp2(i), 44.);
+  }
+}
+
+TEST(ops_eigen, diag_min_max)
 {
   using T = Eigen::MatrixXd;
   T a(5,5);

--- a/tests/functional_small/ops/ops_eigen_diag.cc
+++ b/tests/functional_small/ops/ops_eigen_diag.cc
@@ -152,7 +152,7 @@ TEST(ops_eigen_diag, deep_copy)
 {
   using T = Eigen::MatrixXd;
   T a(6, 6);
-  auto exp = pressio::diag(a);
+  auto exp = pressio::diagonal(a);
   ::pressio::ops::fill(exp, 44.);
 
   // copy to native vector
@@ -164,7 +164,7 @@ TEST(ops_eigen_diag, deep_copy)
 
   // copy to expression
   T a2(6, 6);
-  auto exp2 = pressio::diag(a2);
+  auto exp2 = pressio::diagonal(a2);
   pressio::ops::deep_copy(exp2, exp);
   for (int i = 0; i < 6; ++i){
     ASSERT_DOUBLE_EQ(exp2(i), 44.);

--- a/tests/functional_small/ops/ops_eigen_diag.cc
+++ b/tests/functional_small/ops/ops_eigen_diag.cc
@@ -148,7 +148,7 @@ TEST(ops_eigen_diag, fill)
   ASSERT_DOUBLE_EQ(a(4,4),44.);
 }
 
-TEST(ops_eigen, diag_deep_copy)
+TEST(ops_eigen_diag, deep_copy)
 {
   using T = Eigen::MatrixXd;
   T a(6, 6);
@@ -171,7 +171,7 @@ TEST(ops_eigen, diag_deep_copy)
   }
 }
 
-TEST(ops_eigen, diag_min_max)
+TEST(ops_eigen_diag, min_max)
 {
   using T = Eigen::MatrixXd;
   T a(5,5);

--- a/tests/functional_small/ops/ops_eigen_matrix.cc
+++ b/tests/functional_small/ops/ops_eigen_matrix.cc
@@ -98,7 +98,7 @@ TEST(ops_eigen_matrix, dense_matrix_deep_copy)
   pressio::ops::deep_copy(b,a);
   for (int i=0; i<6; ++i){
    for (int j=0; j<5; ++j){
-    ASSERT_DOUBLE_EQ(a(i,j),44.);
+    ASSERT_DOUBLE_EQ(b(i,j),44.);
    }
   }
 }

--- a/tests/functional_small/ops/ops_eigen_span.cc
+++ b/tests/functional_small/ops/ops_eigen_span.cc
@@ -69,7 +69,7 @@ TEST(ops_eigen_span, fill)
   ASSERT_DOUBLE_EQ(a(5),1.2);
 }
 
-TEST(ops_eigen, span_deep_copy)
+TEST(ops_eigen_span, deep_copy)
 {
   using T = Eigen::VectorXd;
   const int n = 3;
@@ -93,7 +93,7 @@ TEST(ops_eigen, span_deep_copy)
   }
 }
 
-TEST(ops_eigen, span_min_max)
+TEST(ops_eigen_span, min_max)
 {
   using T = Eigen::VectorXd;
   T a(6);

--- a/tests/functional_small/ops/ops_eigen_span.cc
+++ b/tests/functional_small/ops/ops_eigen_span.cc
@@ -69,7 +69,31 @@ TEST(ops_eigen_span, fill)
   ASSERT_DOUBLE_EQ(a(5),1.2);
 }
 
-TEST(ops_eigen_span, min_max)
+TEST(ops_eigen, span_deep_copy)
+{
+  using T = Eigen::VectorXd;
+  const int n = 3;
+  T a(n + 2);
+  auto sp = pressio::span(a, 1, n);
+  ::pressio::ops::fill(sp, 44.);
+
+  // copy to native vector
+  T b(n);
+  pressio::ops::deep_copy(b, sp);
+  for (int i = 0; i < n; ++i){
+    ASSERT_DOUBLE_EQ(b(i), 44.);
+  }
+
+  // copy to expression
+  T a2(n + 2);
+  auto sp2 = pressio::span(a2, 1, n);
+  pressio::ops::deep_copy(sp2, sp);
+  for (int i = 0; i < n; ++i){
+    ASSERT_DOUBLE_EQ(sp2(i), 44.);
+  }
+}
+
+TEST(ops_eigen, span_min_max)
 {
   using T = Eigen::VectorXd;
   T a(6);

--- a/tests/functional_small/ops/ops_eigen_subspan.cc
+++ b/tests/functional_small/ops/ops_eigen_subspan.cc
@@ -124,7 +124,37 @@ TEST(ops_eigen_subspan, fill)
   ASSERT_DOUBLE_EQ(a(3,4),1.);
 }
 
-TEST(ops_eigen_subspan, min_max)
+TEST(ops_eigen, subspan_deep_copy)
+{
+  using T = Eigen::MatrixXd;
+  const int m = 3, n = 2;
+  T a(m + 2, n + 3);
+  std::pair<int,int> r(1, 1 + m);
+  std::pair<int,int> c(2, 2 + n);
+  auto sp = pressio::subspan(a, r, c);
+  ::pressio::ops::fill(sp, 44.);
+
+  // copy to native vector
+  T b(m, n);
+  pressio::ops::deep_copy(b, sp);
+  for (int i = 0; i < m; ++i){
+    for (int j = 0; j < n; ++j){
+      ASSERT_DOUBLE_EQ(b(i, j), 44.);
+    }
+  }
+
+  // copy to expression
+  T a2(m + 2, n + 3);
+  auto sp2 = pressio::subspan(a2, r, c);
+  pressio::ops::deep_copy(sp2, sp);
+  for (int i = 0; i < m; ++i){
+    for (int j = 0; j < n; ++j){
+      ASSERT_DOUBLE_EQ(sp2(i, j), 44.);
+    }
+  }
+}
+
+TEST(ops_eigen, subspan_min_max)
 {
   using T = Eigen::MatrixXd;
   T a(5, 5);

--- a/tests/functional_small/ops/ops_eigen_subspan.cc
+++ b/tests/functional_small/ops/ops_eigen_subspan.cc
@@ -124,7 +124,7 @@ TEST(ops_eigen_subspan, fill)
   ASSERT_DOUBLE_EQ(a(3,4),1.);
 }
 
-TEST(ops_eigen, subspan_deep_copy)
+TEST(ops_eigen_subspan, deep_copy)
 {
   using T = Eigen::MatrixXd;
   const int m = 3, n = 2;
@@ -154,7 +154,7 @@ TEST(ops_eigen, subspan_deep_copy)
   }
 }
 
-TEST(ops_eigen, subspan_min_max)
+TEST(ops_eigen_subspan, min_max)
 {
   using T = Eigen::MatrixXd;
   T a(5, 5);

--- a/tests/functional_small/ops/ops_eigen_vector.cc
+++ b/tests/functional_small/ops/ops_eigen_vector.cc
@@ -108,7 +108,7 @@ TEST(ops_eigen_vector, deep_copy)
   T b(6);
   pressio::ops::deep_copy(b,a);
   for (int i=0; i<6; ++i){
-    ASSERT_DOUBLE_EQ(a(i),44.);
+    ASSERT_DOUBLE_EQ(b(i),44.);
   }
 }
 


### PR DESCRIPTION
refs #518

### Overloads

Eigen `deep_copy` overloads:

| function | input |
|:---:|:---:|
| `deep_copy( T2 & dest, const T1 & src )` | native Eigen containers or Eigen expressions |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_eigen_vector.cc` | `ops_eigen.vector_deep_copy` | `Eigen::VectorXd` |
| `ops_eigen_diag.cc` | `ops_eigen.diag_deep_copy` | `pressio::diag( Eigen::MatrixXd )` copied to the same and to `Eigen::VectorXd` |
| `ops_eigen_span.cc` | `ops_eigen.span_deep_copy` | `pressio::span( Eigen::VectorXd )` copied to the same and to `Eigen::VectorXd` |
| `ops_eigen_matrix.cc` | `ops_eigen.dense_matrix_deep_copy` | `Eigen::MatrixXd` |
| `ops_eigen_subspan.cc` | `ops_eigen.subspan_deep_copy` | `pressio::subspan( Eigen::MatrixXd )` copied to the same and to `Eigen::VectorXd` |
