### PR TITLE
ops: kokkos: revise `deep_copy`

### DIFF
--- a/include/pressio/ops/kokkos/ops_deep_copy.hpp
+++ b/include/pressio/ops/kokkos/ops_deep_copy.hpp
@@ -63,6 +63,7 @@ std::enable_if_t<
   >
 deep_copy(const T1 & dest, const T2 & src)
 {
+  assert((matching_extents<T1, T2>::compare(dest, src)));
   ::Kokkos::deep_copy(dest, src);
 }
 

--- a/include/pressio/ops/kokkos/ops_deep_copy.hpp
+++ b/include/pressio/ops/kokkos/ops_deep_copy.hpp
@@ -64,7 +64,10 @@ std::enable_if_t<
 deep_copy(const T1 & dest, const T2 & src)
 {
   assert((matching_extents<T1, T2>::compare(dest, src)));
-  ::Kokkos::deep_copy(dest, src);
+
+  const auto src_view = impl::get_native(src);
+  const auto dest_view = impl::get_native(dest);
+  ::Kokkos::deep_copy(dest_view, src_view);
 }
 
 }}//end namespace pressio::ops

--- a/include/pressio/ops/kokkos/ops_deep_copy.hpp
+++ b/include/pressio/ops/kokkos/ops_deep_copy.hpp
@@ -53,10 +53,13 @@ namespace pressio{ namespace ops{
 
 template< typename T1, typename T2 >
 std::enable_if_t<
-  (::pressio::is_native_container_kokkos<T1>::value
-  or ::pressio::is_expression_acting_on_kokkos<T1>::value)
-  and (::pressio::is_native_container_kokkos<T2>::value
-  or ::pressio::is_expression_acting_on_kokkos<T2>::value)
+  // common deep_copy constraints
+  ::pressio::Traits<T1>::rank == ::pressio::Traits<T2>::rank
+  // TPL/container specific
+  && (::pressio::is_native_container_kokkos<T1>::value
+   || ::pressio::is_expression_acting_on_kokkos<T1>::value)
+  && (::pressio::is_native_container_kokkos<T2>::value
+   || ::pressio::is_expression_acting_on_kokkos<T2>::value)
   >
 deep_copy(const T1 & dest, const T2 & src)
 {

--- a/tests/functional_small/ops/ops_kokkos_diag.cc
+++ b/tests/functional_small/ops/ops_kokkos_diag.cc
@@ -131,6 +131,20 @@ TEST(ops_kokkos_diag, fill)
   ASSERT_DOUBLE_EQ(a_h(4,4),44.);
 }
 
+TEST(ops_kokkos_diag, deep_copy)
+{
+  mat_t a("a", 6, 6);
+  auto exp = pressio::diag(a);
+  pressio::ops::fill(exp, 44.);
+
+  Kokkos::View<double*> b("b", 6);
+  pressio::ops::deep_copy(b, exp);
+  auto b_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  for (int i = 0; i < 6; ++i){
+    ASSERT_DOUBLE_EQ(b(i), 44.);
+  }
+}
+
 TEST(ops_kokkos_diag, min_max)
 {
   mat_t A("A", 5, 5);

--- a/tests/functional_small/ops/ops_kokkos_diag.cc
+++ b/tests/functional_small/ops/ops_kokkos_diag.cc
@@ -134,7 +134,7 @@ TEST(ops_kokkos_diag, fill)
 TEST(ops_kokkos_diag, deep_copy)
 {
   mat_t a("a", 6, 6);
-  auto exp = pressio::diag(a);
+  auto exp = pressio::diagonal(a);
   pressio::ops::fill(exp, 44.);
 
   Kokkos::View<double*> b("b", 6);

--- a/tests/functional_small/ops/ops_kokkos_span.cc
+++ b/tests/functional_small/ops/ops_kokkos_span.cc
@@ -74,7 +74,7 @@ TEST(ops_kokkos_span, fill)
   ASSERT_DOUBLE_EQ(a_h(5),1.2);
 }
 
-TEST(ops_kokkos_diag, deep_copy)
+TEST(ops_kokkos_span, deep_copy)
 {
   vec_t a("a", 8);
   auto exp = pressio::span(a, 1, 6);

--- a/tests/functional_small/ops/ops_kokkos_span.cc
+++ b/tests/functional_small/ops/ops_kokkos_span.cc
@@ -74,6 +74,20 @@ TEST(ops_kokkos_span, fill)
   ASSERT_DOUBLE_EQ(a_h(5),1.2);
 }
 
+TEST(ops_kokkos_diag, deep_copy)
+{
+  vec_t a("a", 8);
+  auto exp = pressio::span(a, 1, 6);
+  pressio::ops::fill(exp, 44.);
+
+  Kokkos::View<double*> b("b", 6);
+  pressio::ops::deep_copy(b, exp);
+  auto b_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  for (int i = 0; i < 6; ++i){
+    ASSERT_DOUBLE_EQ(b(i), 44.);
+  }
+}
+
 TEST(ops_kokkos_span, min_max)
 {
   vec_t a("a",6);

--- a/tests/functional_small/ops/ops_kokkos_subspan.cc
+++ b/tests/functional_small/ops/ops_kokkos_subspan.cc
@@ -125,7 +125,24 @@ TEST(ops_kokkos_subspan, _fill)
   ASSERT_DOUBLE_EQ(A_h(3,4),1.);
 }
 
-TEST(ops_kokkos_subspan, _min_max)
+TEST(ops_kokkos_subspan, deep_copy)
+{
+  const int m = 2, n = 3;
+  mat_t A("A", m + 3, n + 3);
+  auto A1 = pressio::subspan(A, {1, 1 + m}, {2, 2 + n});
+  pressio::ops::fill(A1, 44.);
+
+  Kokkos::View<double**> B("B", m, n);
+  pressio::ops::deep_copy(B, A1);
+  auto B_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), B);
+  for (int i = 0; i < m; ++i){
+   for (int j = 0; j < n; ++j){
+    ASSERT_DOUBLE_EQ(B_h(i, j), 44.);
+   }
+  }
+}
+
+TEST(ops_kokkos_subspan, min_max)
 {
   mat_t A("A", 6, 6);
   auto A_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), A);


### PR DESCRIPTION
refs #518

### Overloads

Kokkos `deep_copy` overloads:

| function | parameter types |
|:---:|:---:|
| `deep_copy( T2 & dest, const T1 & src )` | Kokkos views or expressions |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_kokkos_vector.cc` | `ops_kokkos.vector_deep_copy` | `Kokkos::View<double*>` |
| `ops_kokkos_diag.cc` | `ops_kokkos.diag_deep_copy` | `pressio::diag( Kokkos::View<double**> )` |
| `ops_kokkos_span.cc` | `ops_kokkos.span_deep_copy` | `pressio::span( Kokkos::View<double*> )` |
| `ops_kokkos_matrix.cc` | `ops_kokkos.dense_matrix_deep_copy` | `Kokkos::View<double**>` |
| `ops_kokkos_subspan.cc` | `ops_kokkos.subspan_deep_copy` | `pressio::subspan( Kokkos::View<double**> )` |
