### PR TITLE
ops: epetra: revise `deep_copy`

### DIFF
--- a/include/pressio/ops/epetra/ops_deep_copy.hpp
+++ b/include/pressio/ops/epetra/ops_deep_copy.hpp
@@ -58,6 +58,7 @@ template<typename T>
   ::pressio::is_multi_vector_epetra<T>::value
   >
 deep_copy(T & dest, const T & src){
+  assert((matching_extents<T, T>::compare(dest, src)));
   dest = src;
 }
 

--- a/include/pressio/ops/epetra/ops_deep_copy.hpp
+++ b/include/pressio/ops/epetra/ops_deep_copy.hpp
@@ -53,7 +53,8 @@ namespace pressio{ namespace ops{
 
 template<typename T>
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_vector_epetra<T>::value or 
+  // TPL/container specific
+  ::pressio::is_vector_epetra<T>::value or
   ::pressio::is_multi_vector_epetra<T>::value
   >
 deep_copy(T & dest, const T & src){


### PR DESCRIPTION
refs #518

### Overloads

Epetra `deep_copy` overloads:

| function | input |
|:---:|:---:|
| `deep_copy( T2 & dest, const T1 & src )` | Epetra vectors or multi-vectors |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_epetra_vector.cc` | `ops_epetra.vector_deep_copy` | `Epetra_Vector` |
| `ops_epetra_multi_vector.cc` | `epetraMultiVectorGlobSize15Fixture.multi_vector_deep_copy` | `Epetra_MultiVector` |
