### PR TITLE
ops: tpetra: revise `deep_copy` overload constraints

### DIFF
--- a/include/pressio/ops/tpetra/ops_deep_copy.hpp
+++ b/include/pressio/ops/tpetra/ops_deep_copy.hpp
@@ -53,7 +53,8 @@ namespace pressio{ namespace ops{
 
 template<typename T>
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_vector_tpetra<T>::value or 
+  // TPL/container specific
+  ::pressio::is_vector_tpetra<T>::value or
   ::pressio::is_multi_vector_tpetra<T>::value
   >
 deep_copy(T & dest, const T & src)


### PR DESCRIPTION
refs #518

### Overloads

Tpetra `deep_copy` overloads:

| function | parameter types |
|:---:|:---:|
| `deep_copy( T2 & dest, const T1 & src )` | Tpetra vectors or multi-vectors |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_tpetra_vector.cc` | `ops_tpetra.vector_deep_copy` | `Tpetra::Vector<>` |
| `ops_tpetra_multi_vector.cc` | `tpetraMultiVectorGlobSize15Fixture.multi_vector_deep_copy` | `Tpetra::MultiVector<>` |