### PR TITLE
ops: tpetra-block: revise `deep_copy`

### DIFF
--- a/include/pressio/ops/tpetra_block/ops_deep_copy.hpp
+++ b/include/pressio/ops/tpetra_block/ops_deep_copy.hpp
@@ -53,6 +53,7 @@ namespace pressio{ namespace ops{
 
 template<typename T>
 ::pressio::mpl::enable_if_t<
+  // TPL/container specific
   ::pressio::is_vector_tpetra_block<T>::value or
   ::pressio::is_multi_vector_tpetra_block<T>::value
   >

--- a/include/pressio/ops/tpetra_block/ops_deep_copy.hpp
+++ b/include/pressio/ops/tpetra_block/ops_deep_copy.hpp
@@ -59,6 +59,8 @@ template<typename T>
   >
 deep_copy(T & dest, const T & src)
 {
+  assert((matching_extents<T, T>::compare(dest, src)));
+
   using sc_t = typename ::pressio::Traits<T>::scalar_type;
   dest.update(::pressio::utils::Constants<sc_t>::one(),
 	      src,

--- a/tests/functional_small/ops/ops_tpetra_block_multi_vector.cc
+++ b/tests/functional_small/ops/ops_tpetra_block_multi_vector.cc
@@ -61,11 +61,11 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture, multi_vector_fill
 
 TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture, multi_vector_deep_copy)
 {
-  ::pressio::ops::fill(*myMv_, -5.);
   auto a = ::pressio::ops::clone(*myMv_);
+  ::pressio::ops::fill(*myMv_, -5.);
   ::pressio::ops::deep_copy(a, *myMv_);
 
-  auto a_h = a.getMultiVectorView().getLocalViewHost(Tpetra::Access::ReadWriteStruct());
+  auto a_h = a.getMultiVectorView().getLocalViewHost(Tpetra::Access::ReadOnly);
   for (int i=0; i<localSize_*blockSize_; ++i){
     for (int j=0; j<numVecs_; ++j){
       EXPECT_DOUBLE_EQ(a_h(i,j), -5.);

--- a/tests/functional_small/ops/ops_tpetra_block_vector.cc
+++ b/tests/functional_small/ops/ops_tpetra_block_vector.cc
@@ -29,11 +29,11 @@ TEST_F(ops_tpetra_block, vector_extent)
 
 TEST_F(ops_tpetra_block, vector_deep_copy)
 {
-  myVector_->putScalar(-5.);
   auto a = pressio::ops::clone(*myVector_);
+  myVector_->putScalar(-5.);
   pressio::ops::deep_copy(a, *myVector_);
 
-  auto a_h = a.getVectorView().getLocalViewHost(Tpetra::Access::ReadWriteStruct());
+  auto a_h = a.getVectorView().getLocalViewHost(Tpetra::Access::ReadOnly);
   for (int i=0; i<localSize_*blockSize_; ++i){
     EXPECT_DOUBLE_EQ(a_h(i,0), -5.);
   }


### PR DESCRIPTION
refs #518

### Overloads

Block Tpetra `deep_copy` overloads:

| function | parameter types |
|:---:|:---:|
| `deep_copy( T2 & dest, const T1 & src )` | Tpetra block vectors or block multi-vectors |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_tpetra_block_vector.cc` | `ops_tpetra_block.vector_deep_copy` | `Tpetra::Vector<>` |
| `ops_tpetra_block_multi_vector.cc` | `tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture.multi_vector_deep_copy` | `Tpetra::MultiVector<>` |