### PR TITLE
ops: teuchos: implementation and test for `deep_copy`

### DIFF
--- a/include/pressio/ops.hpp
+++ b/include/pressio/ops.hpp
@@ -116,6 +116,7 @@ template<class ...> struct matching_extents;
 #ifdef PRESSIO_ENABLE_TPL_TRILINOS
 // Teuchos
 #include "ops/teuchos/ops_extent.hpp"
+#include "ops/teuchos/ops_deep_copy.hpp"
 #include "ops/teuchos/ops_set_zero.hpp"
 #include "ops/teuchos/ops_scale.hpp"
 #include "ops/teuchos/ops_fill.hpp"

--- a/include/pressio/ops/teuchos/ops_deep_copy.hpp
+++ b/include/pressio/ops/teuchos/ops_deep_copy.hpp
@@ -1,0 +1,67 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+// ops_deep_copy.hpp
+//                     		  Pressio
+//                             Copyright 2019
+//    National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+//
+// Under the terms of Contract DE-NA0003525 with NTESS, the
+// U.S. Government retains certain rights in this software.
+//
+// Pressio is licensed under BSD-3-Clause terms of use:
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Francesco Rizzi (fnrizzi@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef OPS_TEUCHOS_OPS_DEEP_COPY_HPP_
+#define OPS_TEUCHOS_OPS_DEEP_COPY_HPP_
+
+namespace pressio{ namespace ops{
+
+template<typename T1, typename T2>
+::pressio::mpl::enable_if_t<
+  // TPL/container specific
+     ::pressio::is_dense_vector_teuchos<T1>::value
+  && ::pressio::is_dense_vector_teuchos<T2>::value
+  >
+deep_copy(T2 & dest, const T1 & src)
+{
+  assert((matching_extents<T2, T1>::compare(dest, src)));
+  dest = src;
+}
+
+}}//end namespace pressio::ops
+#endif  // OPS_TEUCHOS_OPS_DEEP_COPY_HPP_

--- a/tests/functional_small/ops/ops_teuchos_vector.cc
+++ b/tests/functional_small/ops/ops_teuchos_vector.cc
@@ -23,3 +23,14 @@ TEST(ops_teuchos, vector_scale)
   pressio::ops::scale(a, 0.);
   EXPECT_DOUBLE_EQ(a(0), 0.);
 }
+
+TEST(ops_teuchos, vector_deep_copy)
+{
+  const int n = 6;
+  V_t a(n), b(n);
+  ::pressio::ops::fill(a, 44.);
+  pressio::ops::deep_copy(b, a);
+  for (int i = 0; i < n; ++i){
+    ASSERT_DOUBLE_EQ(b(i), 44.);
+  }
+}


### PR DESCRIPTION
refs #518

### Overloads

Teuchos `deep_copy` overloads:

| function | parameter types |
|:---:|:---:|
| `deep_copy( T2 & dest, const T1 & src )` | `Teuchos::SerialDenseVector<OrdinalType, ScalarType>` |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_teuchos_vector.cc` | `ops_teuchos.vector_deep_copy` | `Teuchos::SerialDenseVector<int, double>` |