### PR TITLE
ops: eigen: revise `extent`

### DIFF
--- a/include/pressio/ops/eigen/ops_extent.hpp
+++ b/include/pressio/ops/eigen/ops_extent.hpp
@@ -53,8 +53,9 @@ namespace pressio{ namespace ops{
 
 template<class T, class IndexType>
 mpl::enable_if_t<
+  // TPL/container specific
   ::pressio::is_vector_eigen<T>::value,
-  decltype(std::declval<const T>().size())
+  decltype(std::declval<const T&>().size())
   >
 extent(const T & objectIn, const IndexType i)
 {
@@ -65,9 +66,10 @@ extent(const T & objectIn, const IndexType i)
 
 template<class T, class IndexType>
 mpl::enable_if_t<
+  // TPL/container specific
   ::pressio::is_dense_matrix_eigen<T>::value or
   ::pressio::is_sparse_matrix_eigen<T>::value,
-  decltype(std::declval<const T>().size())
+  decltype(std::declval<const T&>().rows())
   >
 extent(const T & objectIn, const IndexType i)
 {
@@ -81,8 +83,9 @@ extent(const T & objectIn, const IndexType i)
 
 template<class T, class IndexType>
 mpl::enable_if_t<
+  // TPL/container specific
   ::pressio::is_expression_acting_on_eigen<T>::value,
-  decltype(std::declval<const T>().extent(0))
+  decltype(std::declval<const T&>().extent(0))
   >
 extent(const T & objectIn, const IndexType i)
 {

--- a/tests/functional_small/ops/ops_eigen_vector.cc
+++ b/tests/functional_small/ops/ops_eigen_vector.cc
@@ -350,7 +350,7 @@ TEST(ops_eigen, vector_update_nan2)
   EXPECT_DOUBLE_EQ(v(0), 4.0);
 }
 
-TEST(ops_kokkos, vector_update_expr_span)
+TEST(ops_eigen, vector_update_expr_span)
 {
   T v0(5);
   T a0(5);
@@ -371,7 +371,7 @@ TEST(ops_kokkos, vector_update_expr_span)
   EXPECT_DOUBLE_EQ(v(2), 30.0);
 }
 
-TEST(ops_kokkos, vector_update_expr_diag)
+TEST(ops_eigen, vector_update_expr_diag)
 {
   Eigen::Matrix<double, 3, 3> v0;
   Eigen::Matrix<double, 3, 3> a0;


### PR DESCRIPTION
refs #522

### Overloads

Eigen `extent` overloads:

| function | input |
|:---:|:---:|
| `extent(const T & objectIn, const IndexType i)` | native Eigen vector |
| `extent(const T & objectIn, const IndexType i)` | native Eigen matrix (dense or sparse) |
| `extent(const T & objectIn, const IndexType i)` | Eigen expression |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_eigen_vector.cc` | `ops_eigen.vector_extent` | `Eigen::VectorXd` |
| `ops_eigen_diag.cc` | `ops_eigen.diag_extent` | `pressio::diag( Eigen::MatrixXd )` |
| `ops_eigen_span.cc` | `ops_eigen.span_extent` | `pressio::span( Eigen::VectorXd )` |
| `ops_eigen_matrix.cc` | `ops_eigen.dense_matrix_extent` | `Eigen::MatrixXd` |
| `ops_eigen_subspan.cc` | `ops_eigen.subspan_extent` | `pressio::subspan( Eigen::MatrixXd )`|
