### PR TITLE
ops: kokkos: revise `extent` overload constraints

### DIFF
--- a/include/pressio/ops/kokkos/ops_extent.hpp
+++ b/include/pressio/ops/kokkos/ops_extent.hpp
@@ -53,9 +53,10 @@ namespace pressio{ namespace ops{
 
 template<class T, class IndexType>
 mpl::enable_if_t<
-  (::pressio::is_native_container_kokkos<T>::value
-  or ::pressio::is_expression_acting_on_kokkos<T>::value),
-  decltype(std::declval<const T>().extent(0))
+  // TPL/container specific
+  ::pressio::is_native_container_kokkos<T>::value
+  || ::pressio::is_expression_acting_on_kokkos<T>::value,
+  decltype(std::declval<const T&>().extent(0))
   >
 extent(const T & objectIn, const IndexType i)
 {


### PR DESCRIPTION
refs #522

### Overloads

Kokkos `extent` overloads:

| function | parameter types |
|:---:|:---:|
| `extent(const T & objectIn, const IndexType i)` | Kokkos view or expression |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_kokkos_vector.cc` | `ops_kokkos.vector_extent` | `Kokkos::View<double*>` |
| `ops_kokkos_diag.cc` | `ops_kokkos.diag_extent` | `pressio::diag( Kokkos::View<double**> )` |
| `ops_kokkos_span.cc` | `ops_kokkos.span_extent` | `pressio::span( Kokkos::View<double*> )` |
| `ops_kokkos_matrix.cc` | `ops_kokkos.dense_matrix_extent` | `Kokkos::View<double**>` |
| `ops_kokkos_subspan.cc` | `ops_kokkos.subspan_extent` | `pressio::subspan( Kokkos::View<double**> )` |
