### PR TITLE
ops: epetra: revise `extent` overload constraints

### DIFF
--- a/include/pressio/ops/epetra/ops_extent.hpp
+++ b/include/pressio/ops/epetra/ops_extent.hpp
@@ -53,8 +53,9 @@ namespace pressio{ namespace ops{
 
 template <typename T, class IndexType>
 ::pressio::mpl::enable_if_t<
+  // TPL/container specific
   ::pressio::is_vector_epetra<T>::value,
-  ::pressio::ops::impl::global_ordinal_t<T>
+  decltype(std::declval<const T&>().GlobalLength())
   >
 extent(const T & oIn, const IndexType i)
 {
@@ -65,8 +66,9 @@ extent(const T & oIn, const IndexType i)
 
 template <typename T, class IndexType>
 ::pressio::mpl::enable_if_t<
+  // TPL/container specific
   ::pressio::is_multi_vector_epetra<T>::value,
-  ::pressio::ops::impl::global_ordinal_t<T>
+  decltype(std::declval<const T&>().GlobalLength())
   >
 extent(const T & oIn, const IndexType i)
 {


### PR DESCRIPTION
refs #522

### Overloads

Epetra `extent` overloads:

| function | parameter types |
|:---:|:---:|
| `extent(const T & objectIn, const IndexType i)` | `Epetra_Vector` |
| `extent(const T & objectIn, const IndexType i)` | `Epetra_MultiVector` |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_epetra_vector.cc` | `ops_epetra.vector_extent` | `Epetra_Vector` |
| `ops_epetra_multi_vector.cc` | `epetraMultiVectorGlobSize15Fixture.multi_vector_extent` | `Epetra_MultiVector` |
