### PR TITLE
ops: tpetra-block: revise `extent` overload constraints

### DIFF
--- a/include/pressio/ops/tpetra_block/ops_extent.hpp
+++ b/include/pressio/ops/tpetra_block/ops_extent.hpp
@@ -53,8 +53,9 @@ namespace pressio{ namespace ops{
 
 template <typename T, class IndexType>
 ::pressio::mpl::enable_if_t<
+  // TPL/container specific
   ::pressio::is_vector_tpetra_block<T>::value,
-  ::pressio::ops::impl::global_ordinal_t<T>
+  decltype(std::declval<const T&>().getMap()->getGlobalNumElements())
   >
 extent(const T & oIn, const IndexType i)
 {
@@ -65,8 +66,9 @@ extent(const T & oIn, const IndexType i)
 
 template <typename T, class IndexType>
 ::pressio::mpl::enable_if_t<
+  // TPL/container specific
   ::pressio::is_multi_vector_tpetra_block<T>::value,
-  ::pressio::ops::impl::global_ordinal_t<T>
+  decltype(std::declval<const T&>().getMap()->getGlobalNumElements())
   >
 extent(const T & oIn, const IndexType i)
 {


### PR DESCRIPTION
refs #522

### Overloads

Block Tpetra `extent` overloads:

| function | parameter types |
|:---:|:---:|
| `extent(const T & objectIn, const IndexType i)` | Tpetra block vector |
| `extent(const T & objectIn, const IndexType i)` | Tpetra block multi-vector |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_tpetra_block_vector.cc` | `ops_tpetra_block.vector_extent` | `Tpetra::Vector<>` |
| `ops_tpetra_block_multi_vector.cc` | `tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture.multi_vector_extent` | `Tpetra::MultiVector<>` |