### PR TITLE
ops: assume 1 for overranked extents

### DIFF
--- a/include/pressio/expressions/impl/asdiagonalmatrix_classes.hpp
+++ b/include/pressio/expressions/impl/asdiagonalmatrix_classes.hpp
@@ -90,9 +90,7 @@ public:
 
 public:
   size_t extent(size_t i) const{
-    assert(i==0 or i==1);
-    (void) i;
-    return extent_;
+    return (i < 2) ? extent_ : 1;
   }
 
   native_expr_t const & native() const{

--- a/include/pressio/expressions/impl/diag_classes.hpp
+++ b/include/pressio/expressions/impl/diag_classes.hpp
@@ -94,9 +94,7 @@ public:
   }
 
   size_t extent(size_t i) const{
-    assert(i==0);
-    (void) i;
-    return extent_;
+    return (i < 1) ? extent_ : 1;
   }
 
   native_expr_t const & native() const{
@@ -167,9 +165,7 @@ public:
 
 public:
   size_t extent(size_t i) const{
-    assert(i==0);
-    (void) i;
-    return extent_;
+    return (i < 1) ? extent_ : 1;
   }
 
   native_expr_t const & native() const{

--- a/include/pressio/expressions/impl/span_classes.hpp
+++ b/include/pressio/expressions/impl/span_classes.hpp
@@ -96,9 +96,7 @@ public:
 
 public:
   size_t extent(size_t i) const{
-    assert(i==0);
-    (void) i;
-    return extent_;
+    return (i == 0) ? extent_ : 1;
   }
 
   native_expr_t const & native() const{
@@ -180,9 +178,7 @@ public:
 
 public:
   size_t extent(size_t i) const{
-    assert(i==0);
-    (void) i;
-    return extent_;
+    return (i == 0) ? extent_ : 1;
   }
 
   native_expr_t const & native() const{

--- a/include/pressio/expressions/impl/subspan_classes.hpp
+++ b/include/pressio/expressions/impl/subspan_classes.hpp
@@ -113,7 +113,13 @@ public:
 
 public:
   size_t extent(size_t i) const{
-    return (i==0) ? numRows_ : numCols_;
+    if (i == 0) {
+      return numRows_;
+    } else if (i == 1) {
+      return numCols_;
+    } else {
+      return 1;
+    }
   }
 
   native_expr_t const & native() const{
@@ -203,7 +209,13 @@ public:
 
 public:
   size_t extent(size_t i) const{
-    return (i==0) ? numRows_ : numCols_;
+    if (i == 0) {
+      return numRows_;
+    } else if (i == 1) {
+      return numCols_;
+    } else {
+      return 1;
+    }
   }
 
   native_expr_t const & native() const{

--- a/include/pressio/ops/eigen/ops_extent.hpp
+++ b/include/pressio/ops/eigen/ops_extent.hpp
@@ -59,9 +59,7 @@ mpl::enable_if_t<
   >
 extent(const T & objectIn, const IndexType i)
 {
-  assert(i==0);
-  (void) i;
-  return objectIn.size();
+  return (i == 0) ? objectIn.size() : 1;
 }
 
 template<class T, class IndexType>
@@ -73,11 +71,12 @@ mpl::enable_if_t<
   >
 extent(const T & objectIn, const IndexType i)
 {
-  if (i==0){
+  if (i == 0){
     return objectIn.rows();
-  }
-  else{
+  } else if (i == 1) {
     return objectIn.cols();
+  } else {
+    return 1;
   }
 }
 

--- a/include/pressio/ops/epetra/ops_extent.hpp
+++ b/include/pressio/ops/epetra/ops_extent.hpp
@@ -59,9 +59,7 @@ template <typename T, class IndexType>
   >
 extent(const T & oIn, const IndexType i)
 {
-  assert(i==0);
-  (void) i;
-  return oIn.GlobalLength();
+  return (i == 0) ? oIn.GlobalLength() : 1;
 }
 
 template <typename T, class IndexType>
@@ -72,8 +70,13 @@ template <typename T, class IndexType>
   >
 extent(const T & oIn, const IndexType i)
 {
-  assert(i<=1);
-  return (i==0) ? oIn.GlobalLength() : oIn.NumVectors();
+  if (i == 0) {
+    return oIn.GlobalLength();
+  } else if (i == 1) {
+    return oIn.NumVectors();
+  } else {
+    return 1;
+  }
 }
 
 }}

--- a/include/pressio/ops/kokkos/ops_extent.hpp
+++ b/include/pressio/ops/kokkos/ops_extent.hpp
@@ -60,7 +60,7 @@ mpl::enable_if_t<
   >
 extent(const T & objectIn, const IndexType i)
 {
-  return objectIn.extent(i);
+  return (i < ::pressio::Traits<T>::rank) ? objectIn.extent(i) : 1;
 }
 
 }}

--- a/include/pressio/ops/tpetra/ops_extent.hpp
+++ b/include/pressio/ops/tpetra/ops_extent.hpp
@@ -59,9 +59,7 @@ template <typename T, class IndexType>
   >
 extent(const T & oIn, const IndexType i)
 {
-  assert(i==0);
-  (void) i;
-  return oIn.getGlobalLength();
+  return (i == 0) ? oIn.getGlobalLength() : 1;
 }
 
 template <typename T, class IndexType>
@@ -72,8 +70,13 @@ template <typename T, class IndexType>
   >
 extent(const T & oIn, const IndexType i)
 {
-  assert(i<=1);
-  return (i==0) ? oIn.getGlobalLength() : oIn.getNumVectors();
+  if (i == 0) {
+    return oIn.getGlobalLength();
+  } else if (i == 1) {
+    return oIn.getNumVectors();
+  } else {
+    return 1;
+  }
 }
 
 }}

--- a/include/pressio/ops/tpetra_block/ops_extent.hpp
+++ b/include/pressio/ops/tpetra_block/ops_extent.hpp
@@ -59,9 +59,11 @@ template <typename T, class IndexType>
   >
 extent(const T & oIn, const IndexType i)
 {
-  assert(i==0);
-  (void) i;
-  return oIn.getMap()->getGlobalNumElements();
+  if (i == 0) {
+    return oIn.getMap()->getGlobalNumElements();
+  } else {
+    return 1;
+  }
 }
 
 template <typename T, class IndexType>
@@ -72,8 +74,13 @@ template <typename T, class IndexType>
   >
 extent(const T & oIn, const IndexType i)
 {
-  assert(i<=1);
-  return (i==0) ? oIn.getMap()->getGlobalNumElements() : oIn.getNumVectors();
+  if (i == 0) {
+    return oIn.getMap()->getGlobalNumElements();
+  } else if (i == 1) {
+    return oIn.getNumVectors();
+  } else {
+    return 1;
+  }
 }
 
 }}

--- a/tests/functional_small/ops/ops_eigen_diag.cc
+++ b/tests/functional_small/ops/ops_eigen_diag.cc
@@ -10,6 +10,7 @@ TEST(ops_eigen, diag_extent)
   mat_t a(5,5);
   auto ex = pressio::diag(a);
   ASSERT_TRUE(pressio::ops::extent(ex,0)==5);
+  ASSERT_TRUE(pressio::ops::extent(ex,1)==1); // check extent over the rank
 }
 
 TEST(ops_eigen, diag_abs)

--- a/tests/functional_small/ops/ops_eigen_matrix.cc
+++ b/tests/functional_small/ops/ops_eigen_matrix.cc
@@ -34,6 +34,7 @@ TEST(ops_eigen, dense_matrix_extent)
   T x(6,8);
   ASSERT_TRUE(pressio::ops::extent(x,0) == 6);
   ASSERT_TRUE(pressio::ops::extent(x,1) == 8);
+  ASSERT_TRUE(pressio::ops::extent(x,2) == 1); // check extent over the rank
 }
 
 TEST(ops_eigen, dense_matrix_scale)

--- a/tests/functional_small/ops/ops_eigen_span.cc
+++ b/tests/functional_small/ops/ops_eigen_span.cc
@@ -8,6 +8,7 @@ TEST(ops_eigen, span_extent)
   T a(8);
   auto ex = pressio::span(a,5,2);
   ASSERT_TRUE(pressio::ops::extent(ex,0)==2);
+  ASSERT_TRUE(pressio::ops::extent(ex,1)==1); // check extent over the rank
 }
 
 TEST(ops_eigen, span_abs)

--- a/tests/functional_small/ops/ops_eigen_subspan.cc
+++ b/tests/functional_small/ops/ops_eigen_subspan.cc
@@ -11,8 +11,9 @@ TEST(ops_eigen, subspan_extent)
   std::pair<int,int> c(2,5);
 
   auto ex = pressio::subspan(A,r,c);
-  ASSERT_TRUE(pressio::ops::extent(ex,0)==2);
-  ASSERT_TRUE(pressio::ops::extent(ex,1)==3);
+  ASSERT_EQ(2, pressio::ops::extent(ex, 0));
+  ASSERT_EQ(3, pressio::ops::extent(ex, 1));
+  ASSERT_EQ(1, pressio::ops::extent(ex, 2)); // check extent over the rank
 }
 
 TEST(ops_eigen, subspan_scale)

--- a/tests/functional_small/ops/ops_eigen_vector.cc
+++ b/tests/functional_small/ops/ops_eigen_vector.cc
@@ -27,6 +27,7 @@ TEST(ops_eigen, vector_extent)
 {
   T x(6);
   ASSERT_TRUE(pressio::ops::extent(x,0)== 6);
+  ASSERT_TRUE(pressio::ops::extent(x,1)== 1); // check extent over the rank
 }
 
 TEST(ops_eigen, vector_abs)

--- a/tests/functional_small/ops/ops_epetra_multi_vector.cc
+++ b/tests/functional_small/ops/ops_epetra_multi_vector.cc
@@ -25,6 +25,7 @@ TEST_F(epetraMultiVectorGlobSize15Fixture, multi_vector_extent)
 {
     ASSERT_TRUE(pressio::ops::extent(*myMv_,0) == numProc_ * localSize_);
     ASSERT_TRUE(pressio::ops::extent(*myMv_,1) == numVecs_);
+    ASSERT_TRUE(pressio::ops::extent(*myMv_,2) == 1); // check extent over the rank
 }
 
 TEST_F(epetraMultiVectorGlobSize15Fixture, multi_vector_deep_copy)

--- a/tests/functional_small/ops/ops_epetra_vector.cc
+++ b/tests/functional_small/ops/ops_epetra_vector.cc
@@ -23,6 +23,7 @@ TEST_F(ops_epetra, vector_clone)
 TEST_F(ops_epetra, vector_extent)
 {
     ASSERT_TRUE(pressio::ops::extent(*myVector_,0) == numProc_ * 5.);
+    ASSERT_TRUE(pressio::ops::extent(*myVector_,1) == 1); // check extent over the rank
 }
 
 TEST_F(ops_epetra, vector_deep_copy)

--- a/tests/functional_small/ops/ops_kokkos_diag.cc
+++ b/tests/functional_small/ops/ops_kokkos_diag.cc
@@ -10,6 +10,7 @@ TEST(ops_kokkos, diag_extent)
   mat_t a("a", 5,5);
   auto ex = pressio::diag(a);
   ASSERT_TRUE(pressio::ops::extent(ex,0)==5);
+  ASSERT_TRUE(pressio::ops::extent(ex,1)==1); // check extent over the rank
 }
 
 TEST(ops_kokkos, diag_abs)
@@ -220,7 +221,7 @@ TEST(ops_kokkos, diag_pow)
   }
   Kokkos::deep_copy(a, a_h);
 
-  Eigen::VectorXd gold(5); 
+  Eigen::VectorXd gold(5);
   gold << 0.,6.,12.,18.,24.;
 
   auto exp = pressio::diag(a);
@@ -364,4 +365,3 @@ TEST(ops_kokkos, diag_elementwiseMultiply)
   EXPECT_DOUBLE_EQ( M1_h(1,1), 14.0);
   EXPECT_DOUBLE_EQ( M1_h(2,2), 23.0);
 }
-

--- a/tests/functional_small/ops/ops_kokkos_matrix.cc
+++ b/tests/functional_small/ops/ops_kokkos_matrix.cc
@@ -31,6 +31,7 @@ TEST(ops_kokkos, dense_matrix_extent)
   Kokkos::View<double**> A("A", 6,8);
   ASSERT_TRUE(pressio::ops::extent(A,0) == 6);
   ASSERT_TRUE(pressio::ops::extent(A,1) == 8);
+  ASSERT_TRUE(pressio::ops::extent(A,2) == 1); // check extent over the rank
 }
 
 TEST(ops_kokkos, dense_matrix_scale)

--- a/tests/functional_small/ops/ops_kokkos_span.cc
+++ b/tests/functional_small/ops/ops_kokkos_span.cc
@@ -10,6 +10,7 @@ TEST(ops_kokkos, span_extent)
   vec_t a("a", 8);
   auto ex = pressio::span(a,5,2);
   ASSERT_TRUE(pressio::ops::extent(ex,0)==2);
+  ASSERT_TRUE(pressio::ops::extent(ex,1)==1); // check extent over the rank
 }
 
 TEST(ops_kokkos, span_abs)

--- a/tests/functional_small/ops/ops_kokkos_subspan.cc
+++ b/tests/functional_small/ops/ops_kokkos_subspan.cc
@@ -14,6 +14,7 @@ TEST(ops_kokkos, subspan_extent)
   auto ex = pressio::subspan(A,r,c);
   ASSERT_TRUE(pressio::ops::extent(ex,0)==2);
   ASSERT_TRUE(pressio::ops::extent(ex,1)==3);
+  ASSERT_TRUE(pressio::ops::extent(ex,2)==1); // check extent over the rank
 }
 
 TEST(ops_kokkos, subspan_scale)

--- a/tests/functional_small/ops/ops_kokkos_vector.cc
+++ b/tests/functional_small/ops/ops_kokkos_vector.cc
@@ -52,6 +52,7 @@ TEST(ops_kokkos, vector_extent)
 {
   Kokkos::View<double*> a("a", 6);
   ASSERT_TRUE(pressio::ops::extent(a,0)== 6);
+  ASSERT_TRUE(pressio::ops::extent(a,1)== 1); // check extent over the rank
 }
 
 TEST(ops_kokkos, vector_abs)

--- a/tests/functional_small/ops/ops_tpetra_block_multi_vector.cc
+++ b/tests/functional_small/ops/ops_tpetra_block_multi_vector.cc
@@ -27,6 +27,7 @@ TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture, multi_vector_exte
 {
   ASSERT_TRUE(pressio::ops::extent(*myMv_,0) == numProc_ * localSize_);
   ASSERT_TRUE(pressio::ops::extent(*myMv_,1) == numVecs_);
+  ASSERT_TRUE(pressio::ops::extent(*myMv_,2) == 1); // check extent over the rank
 }
 
 TEST_F(tpetraBlockMultiVectorGlobSize15NVec3BlockSize4Fixture, multi_vector_setzero)

--- a/tests/functional_small/ops/ops_tpetra_block_vector.cc
+++ b/tests/functional_small/ops/ops_tpetra_block_vector.cc
@@ -25,6 +25,7 @@ TEST_F(ops_tpetra_block, vector_clone)
 TEST_F(ops_tpetra_block, vector_extent)
 {
     ASSERT_TRUE(pressio::ops::extent(*myVector_,0) == numProc_ * 5.);
+    ASSERT_TRUE(pressio::ops::extent(*myVector_,1) == 1); // check extent over the rank
 }
 
 TEST_F(ops_tpetra_block, vector_deep_copy)

--- a/tests/functional_small/ops/ops_tpetra_multi_vector.cc
+++ b/tests/functional_small/ops/ops_tpetra_multi_vector.cc
@@ -27,6 +27,7 @@ TEST_F(tpetraMultiVectorGlobSize15Fixture, multi_vector_extent)
 {
     ASSERT_TRUE(pressio::ops::extent(*myMv_,0) == numProc_ * localSize_);
     ASSERT_TRUE(pressio::ops::extent(*myMv_,1) == numVecs_);
+    ASSERT_TRUE(pressio::ops::extent(*myMv_,2) == 1); // check extent over the rank
 }
 
 TEST_F(tpetraMultiVectorGlobSize15Fixture, multi_vector_setzero)

--- a/tests/functional_small/ops/ops_tpetra_vector.cc
+++ b/tests/functional_small/ops/ops_tpetra_vector.cc
@@ -25,6 +25,7 @@ TEST_F(ops_tpetra, vector_clone)
 TEST_F(ops_tpetra, vector_extent)
 {
     ASSERT_TRUE(pressio::ops::extent(*myVector_,0) == numProc_ * 5);
+    ASSERT_TRUE(pressio::ops::extent(*myVector_,1) == 1); // check extent over the rank
 }
 
 TEST_F(ops_tpetra, vector_deep_copy)


### PR DESCRIPTION
Based on https://github.com/Pressio/pressio/pull/513#discussion_r1050558365 from @fnrizzi:
> it should not return 0 if i!=0 , because a vector has 1 column.
> 
> ```
>   return (i == 0) ? objectIn.length() : 1;
> ```
this PR makes `presssio::ops::extent()` consistently return 1 for over-the-rank extents and adds related unit tests for each TPL implementation.
