### PR TITLE
ops: eigen: revise `abs`

### DIFF
--- a/include/pressio/ops/eigen/ops_abs.hpp
+++ b/include/pressio/ops/eigen/ops_abs.hpp
@@ -53,14 +53,18 @@ namespace pressio{ namespace ops{
 
 template <class T1, class T2>
 ::pressio::mpl::enable_if_t<
-  /* a bit restrictive but fine for now */
-  ::pressio::all_have_traits_and_same_scalar<T1, T2>::value
-  && (::pressio::is_vector_eigen<T1>::value
-  || ::pressio::is_expression_acting_on_eigen<T1>::value)
-  && (::pressio::is_vector_eigen<T1>::value
-  || ::pressio::is_expression_acting_on_eigen<T1>::value)
-  && ::pressio::Traits<T1>::rank == 1
+  // common abs constraints
+     ::pressio::Traits<T1>::rank == 1
   && ::pressio::Traits<T2>::rank == 1
+  // TPL/container specific
+  && (::pressio::is_vector_eigen<T1>::value
+   || ::pressio::is_expression_acting_on_eigen<T1>::value)
+  && (::pressio::is_vector_eigen<T1>::value
+   || ::pressio::is_expression_acting_on_eigen<T1>::value)
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<T1, T2>::value
+  && (std::is_floating_point<typename ::pressio::Traits<T1>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T1>::scalar_type>::value)
   >
 abs(T1 & y, const T2 & x)
 {

--- a/include/pressio/ops/eigen/ops_abs.hpp
+++ b/include/pressio/ops/eigen/ops_abs.hpp
@@ -68,9 +68,12 @@ template <class T1, class T2>
   >
 abs(T1 & y, const T2 & x)
 {
+  const auto size = ::pressio::ops::extent(x, 0);
 
-  using ord_t = decltype( ::pressio::ops::extent(x, 0) );
-  for (ord_t i=0; i< ::pressio::ops::extent(x, 0); ++i){
+  assert(::pressio::ops::extent(y, 0) == size);
+
+  using ord_t = typename std::remove_const<decltype(size)>::type;
+  for (ord_t i = 0; i < size; ++i) {
     y(i) = std::abs(x(i));
   }
 }

--- a/tests/functional_small/ops/ops_eigen_span.cc
+++ b/tests/functional_small/ops/ops_eigen_span.cc
@@ -18,7 +18,7 @@ TEST(ops_eigen, span_abs)
   a.setConstant(-1);
   auto ex = pressio::span(a,5,2);
 
-  T y(5);
+  T y(2);
   pressio::ops::abs(y,ex);
   ASSERT_DOUBLE_EQ(y(0),1.);
   ASSERT_DOUBLE_EQ(y(1),1.);


### PR DESCRIPTION
refs #516

### Overloads

Eigen `abs` overloads:

| function | parameter types | remarks |
|:---:|:---:|:---:|
| `abs(T1 & y, const T2 & x)` | Eigen native vectors or rank-1 expressions | requires underlying scalar type<br>to be known integral of floating-point type |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_eigen_vector.cc` | `ops_eigen.vector_abs` | `Eigen::VectorXd` |
| `ops_eigen_diag.cc` | `ops_eigen.diag_abs` | `pressio::diag( Eigen::MatrixXd )` |
| `ops_eigen_span.cc` | `ops_eigen.span_abs` | `pressio::span( Eigen::VectorXd )` |
