### PR TITLE
ops: tpetra: revise `abs`

### DIFF
--- a/include/pressio/ops/tpetra/ops_abs.hpp
+++ b/include/pressio/ops/tpetra/ops_abs.hpp
@@ -53,8 +53,16 @@ namespace pressio{ namespace ops{
 
 template <typename T1, class T2>
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_vector_tpetra<T1>::value and
-  ::pressio::is_vector_tpetra<T2>::value
+  // common abs constraints
+     ::pressio::Traits<T1>::rank == 1
+  && ::pressio::Traits<T2>::rank == 1
+  // TPL/container specific
+  && ::pressio::is_vector_tpetra<T1>::value
+  && ::pressio::is_vector_tpetra<T2>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<T1, T2>::value
+  && (std::is_floating_point<typename ::pressio::Traits<T1>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T1>::scalar_type>::value)
   >
 abs(T1 & y, const T2 & x)
 {

--- a/include/pressio/ops/tpetra/ops_abs.hpp
+++ b/include/pressio/ops/tpetra/ops_abs.hpp
@@ -66,6 +66,8 @@ template <typename T1, class T2>
   >
 abs(T1 & y, const T2 & x)
 {
+  assert(::pressio::ops::extent(y, 0) == ::pressio::ops::extent(x, 0));
+
   y.abs(x);
 }
 

--- a/include/pressio/ops/tpetra/ops_abs.hpp
+++ b/include/pressio/ops/tpetra/ops_abs.hpp
@@ -53,11 +53,7 @@ namespace pressio{ namespace ops{
 
 template <typename T1, class T2>
 ::pressio::mpl::enable_if_t<
-  // common abs constraints
-     ::pressio::Traits<T1>::rank == 1
-  && ::pressio::Traits<T2>::rank == 1
-  // TPL/container specific
-  && ::pressio::is_vector_tpetra<T1>::value
+     ::pressio::is_vector_tpetra<T1>::value
   && ::pressio::is_vector_tpetra<T2>::value
   // scalar compatibility
   && ::pressio::all_have_traits_and_same_scalar<T1, T2>::value
@@ -67,7 +63,6 @@ template <typename T1, class T2>
 abs(T1 & y, const T2 & x)
 {
   assert(::pressio::ops::extent(y, 0) == ::pressio::ops::extent(x, 0));
-
   y.abs(x);
 }
 


### PR DESCRIPTION
refs #516

### Overloads

Tpetra `abs` overloads:

| function | parameter types |
|:---:|:---:|
| `abs(T1 & y, const T2 & x)` | Tpetra vector |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_tpetra_vector.cc` | `ops_tpetra.vector_abs` | `Tpetra::Vector<>` |