### PR TITLE
ops: tpetra-block: revise `abs`

### DIFF
--- a/include/pressio/ops/tpetra_block/ops_abs.hpp
+++ b/include/pressio/ops/tpetra_block/ops_abs.hpp
@@ -67,6 +67,8 @@ template <typename T1, class T2>
   >
 abs(T1 & y, const T2 & x)
 {
+  assert(::pressio::ops::extent(y, 0) == ::pressio::ops::extent(x, 0));
+
   auto y_tpetraview = y.getVectorView();
   auto x_tpetraview = const_cast<T2 &>(x).getVectorView();
   y_tpetraview.abs(x_tpetraview);

--- a/include/pressio/ops/tpetra_block/ops_abs.hpp
+++ b/include/pressio/ops/tpetra_block/ops_abs.hpp
@@ -54,8 +54,16 @@ namespace pressio{ namespace ops{
 // y= abs(x)
 template <typename T1, class T2>
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_vector_tpetra_block<T1>::value and
-  ::pressio::is_vector_tpetra_block<T2>::value
+  // common abs constraints
+     ::pressio::Traits<T1>::rank == 1
+  && ::pressio::Traits<T2>::rank == 1
+  // TPL/container specific
+  && ::pressio::is_vector_tpetra_block<T1>::value
+  && ::pressio::is_vector_tpetra_block<T2>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<T1, T2>::value
+  && (std::is_floating_point<typename ::pressio::Traits<T1>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T1>::scalar_type>::value)
   >
 abs(T1 & y, const T2 & x)
 {

--- a/include/pressio/ops/tpetra_block/ops_abs.hpp
+++ b/include/pressio/ops/tpetra_block/ops_abs.hpp
@@ -54,11 +54,7 @@ namespace pressio{ namespace ops{
 // y= abs(x)
 template <typename T1, class T2>
 ::pressio::mpl::enable_if_t<
-  // common abs constraints
-     ::pressio::Traits<T1>::rank == 1
-  && ::pressio::Traits<T2>::rank == 1
-  // TPL/container specific
-  && ::pressio::is_vector_tpetra_block<T1>::value
+     ::pressio::is_vector_tpetra_block<T1>::value
   && ::pressio::is_vector_tpetra_block<T2>::value
   // scalar compatibility
   && ::pressio::all_have_traits_and_same_scalar<T1, T2>::value


### PR DESCRIPTION
refs #516

### Overloads

Block Tpetra `abs` overloads:

| function | parameter types |
|:---:|:---:|
| `abs(T1 & y, const T2 & x)` | Tpetra block vector |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_tpetra_block_vector.cc` | `ops_tpetra_block.vector_abs` | `Tpetra::BlockVector<>` |
