### PR TITLE
ops: eigen: revise `elementwise_multiply`

### DIFF
--- a/include/pressio/ops/eigen/ops_elementwise_multiply.hpp
+++ b/include/pressio/ops/eigen/ops_elementwise_multiply.hpp
@@ -87,13 +87,17 @@ elementwise_multiply(const alpha_t & alpha,
   assert(::pressio::ops::extent(x, 0)==::pressio::ops::extent(z, 0));
   assert(::pressio::ops::extent(z, 0)==::pressio::ops::extent(y, 0));
 
+  using sc_t = typename ::pressio::Traits<T>::scalar_type;
+  sc_t alpha_{alpha};
+  sc_t beta_{beta};
+
   auto & y_n = impl::get_native(y);
   const auto & x_n = impl::get_native(x);
   const auto & z_n = impl::get_native(z);
-  if (beta == static_cast<beta_t>(0)) {
-    y_n = alpha * x_n.cwiseProduct(z_n);
+  if (beta_ == static_cast<sc_t>(0)) {
+    y_n = alpha_ * x_n.cwiseProduct(z_n);
   } else {
-    y_n = beta * y_n + alpha * x_n.cwiseProduct(z_n);
+    y_n = beta_ * y_n + alpha_ * x_n.cwiseProduct(z_n);
   }
 }
 

--- a/include/pressio/ops/eigen/ops_elementwise_multiply.hpp
+++ b/include/pressio/ops/eigen/ops_elementwise_multiply.hpp
@@ -57,21 +57,26 @@ namespace pressio{ namespace ops{
 
 template <class T, class T1, class T2, class alpha_t, class beta_t>
 ::pressio::mpl::enable_if_t<
-     ::pressio::all_have_traits_and_same_scalar<T, T1, T2>::value
+  // common elementwise_multiply constraints
+     ::pressio::Traits<T>::rank == 1
+  && ::pressio::Traits<T1>::rank == 1
+  && ::pressio::Traits<T2>::rank == 1
+  // TPL/container specific
   && (::pressio::is_native_container_eigen<T>::value
   || ::pressio::is_expression_acting_on_eigen<T>::value)
   && (::pressio::is_native_container_eigen<T1>::value
   || ::pressio::is_expression_acting_on_eigen<T1>::value)
   && (::pressio::is_native_container_eigen<T2>::value
   || ::pressio::is_expression_acting_on_eigen<T2>::value)
-  && ::pressio::Traits<T>::rank == 1
-  && ::pressio::Traits<T1>::rank == 1
-  && ::pressio::Traits<T2>::rank == 1
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<T, T1, T2>::value
   /* constrained via is_convertible because the impl is using
      Eigen native operations which are based on expressions and require
      coefficients to be convertible to scalar types of the vector/matrices */
   && std::is_convertible<alpha_t, typename ::pressio::Traits<T>::scalar_type>::value
   && std::is_convertible<beta_t,  typename ::pressio::Traits<T>::scalar_type>::value
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value)
   >
 elementwise_multiply(const alpha_t & alpha,
 		     const T & x,


### PR DESCRIPTION
refs #523

### Overloads

Eigen `elementwise_multiply` has one overload which requires the underlying scalar type to be the same for `T`, `T1` and `T2` and to be known integral of floating-point type:
```cpp
elementwise_multiply(const alpha_t & alpha, const T & x, const T1 & z, const beta_t & beta, T2 & y)
```

| type name | requirements |
|:---:|:---|
| `T`, `T1`, `T2` | ● each can be Eigen native vector or rank-1 expression<br>● all must have same underlying scalar type |
| `alpha_t`, `beta_t` | must be convertible to the scalar type |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_eigen_vector.cc` | `ops_eigen.vector_elementwiseMultiply` | `Eigen::VectorXd` |
| `ops_eigen_diag.cc` | `ops_eigen.diag_elementwiseMultiply` | `pressio::diag( Eigen::MatrixXd )` |
| `ops_eigen_span.cc` | `ops_eigen.span_elementwiseMultiply` | `pressio::span( Eigen::VectorXd )` |
