### PR TITLE
ops: kokkos: revise `elementwise_multiply`

### DIFF
--- a/include/pressio/ops/kokkos/ops_elementwise_multiply.hpp
+++ b/include/pressio/ops/kokkos/ops_elementwise_multiply.hpp
@@ -56,7 +56,7 @@ namespace pressio{ namespace ops{
 //----------------------------------------------------------------------
 // computing elementwise:  y = beta * y + alpha * x * z
 //----------------------------------------------------------------------
-template <typename T, typename T1, typename T2>
+template <typename T, typename T1, typename T2, typename alpha_t, typename beta_t>
 ::pressio::mpl::enable_if_t<
       (::pressio::is_native_container_kokkos<T>::value
   or ::pressio::is_expression_acting_on_kokkos<T>::value)
@@ -67,17 +67,24 @@ template <typename T, typename T1, typename T2>
   and ::pressio::Traits<T>::rank == 1
   and ::pressio::Traits<T1>::rank == 1
   and ::pressio::Traits<T2>::rank == 1
+  && std::is_convertible<alpha_t, typename ::pressio::Traits<T>::scalar_type>::value
+  && std::is_convertible<beta_t,  typename ::pressio::Traits<T>::scalar_type>::value
   >
-elementwise_multiply(typename ::pressio::Traits<T>::scalar_type alpha,
+elementwise_multiply(alpha_t alpha,
 		     const T & x,
 		     const T1 & z,
-		     typename ::pressio::Traits<T>::scalar_type beta,
+		     beta_t beta,
 		     T2 & y)
 {
   assert(x.extent(0) == z.extent(0));
   assert(z.extent(0) == y.extent(0));
-  KokkosBlas::mult(beta, impl::get_native(y),
-    alpha, impl::get_native(x), impl::get_native(z) );
+
+  using sc_t = typename ::pressio::Traits<T>::scalar_type;
+  sc_t alpha_{alpha};
+  sc_t beta_{beta};
+
+  KokkosBlas::mult(beta_, impl::get_native(y),
+    alpha_, impl::get_native(x), impl::get_native(z) );
 }
 
 }}//end namespace pressio::ops

--- a/include/pressio/ops/kokkos/ops_elementwise_multiply.hpp
+++ b/include/pressio/ops/kokkos/ops_elementwise_multiply.hpp
@@ -58,17 +58,23 @@ namespace pressio{ namespace ops{
 //----------------------------------------------------------------------
 template <typename T, typename T1, typename T2, typename alpha_t, typename beta_t>
 ::pressio::mpl::enable_if_t<
-      (::pressio::is_native_container_kokkos<T>::value
-  or ::pressio::is_expression_acting_on_kokkos<T>::value)
-  and (::pressio::is_native_container_kokkos<T1>::value
-  or ::pressio::is_expression_acting_on_kokkos<T1>::value)
-  and (::pressio::is_native_container_kokkos<T2>::value
-  or ::pressio::is_expression_acting_on_kokkos<T2>::value)
-  and ::pressio::Traits<T>::rank == 1
-  and ::pressio::Traits<T1>::rank == 1
-  and ::pressio::Traits<T2>::rank == 1
+  // common elementwise_multiply constraints
+     ::pressio::Traits<T>::rank == 1
+  && ::pressio::Traits<T1>::rank == 1
+  && ::pressio::Traits<T2>::rank == 1
+  // TPL/container specific
+  && (::pressio::is_native_container_kokkos<T>::value
+   || ::pressio::is_expression_acting_on_kokkos<T>::value)
+  && (::pressio::is_native_container_kokkos<T1>::value
+   || ::pressio::is_expression_acting_on_kokkos<T1>::value)
+  && (::pressio::is_native_container_kokkos<T2>::value
+   || ::pressio::is_expression_acting_on_kokkos<T2>::value)
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<T, T1, T2>::value
   && std::is_convertible<alpha_t, typename ::pressio::Traits<T>::scalar_type>::value
   && std::is_convertible<beta_t,  typename ::pressio::Traits<T>::scalar_type>::value
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value)
   >
 elementwise_multiply(alpha_t alpha,
 		     const T & x,


### PR DESCRIPTION
refs #523

### Overloads

Kokkos `elementwise_multiply` has one overload which requires the underlying scalar type to be the same for `T`, `T1` and `T2` and to be known integral of floating-point type:
```cpp
elementwise_multiply(const alpha_t & alpha, const T & x, const T1 & z, const beta_t & beta, T2 & y)
```

| type name | requirements |
|:---:|:---|
| `T`, `T1`, `T2` | ● each can be native Kokkos view or rank-1 expression<br>● all must have same underlying scalar type |
| `alpha_t`, `beta_t` | must be convertible to the scalar type |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_kokkos_vector.cc` | `ops_kokkos.vector_elementwiseMultiply` | `Kokkos::View<double*>` |
| `ops_kokkos_diag.cc` | `ops_kokkos.diag_elementwiseMultiply` | `pressio::diag( Kokkos::View<double**> )` |
| `ops_kokkos_span.cc` | `ops_kokkos.span_elementwiseMultiply` | `pressio::span( Kokkos::View<double*> )` |
