### PR TITLE
ops: tpetra-block: revise `elementwise_multiply`

### DIFF
--- a/include/pressio/ops/tpetra_block/ops_elementwise_multiply.hpp
+++ b/include/pressio/ops/tpetra_block/ops_elementwise_multiply.hpp
@@ -56,12 +56,7 @@ namespace pressio{ namespace ops{
 //----------------------------------------------------------------------
 template <typename T, typename T1, typename T2, class alpha_t, class beta_t>
 ::pressio::mpl::enable_if_t<
-  // common elementwise_multiply constraints
-     ::pressio::Traits<T>::rank == 1
-  && ::pressio::Traits<T1>::rank == 1
-  && ::pressio::Traits<T2>::rank == 1
-  // TPL/container specific
-  && ::pressio::is_vector_tpetra_block<T>::value
+     ::pressio::is_vector_tpetra_block<T>::value
   && ::pressio::is_vector_tpetra_block<T1>::value
   && ::pressio::is_vector_tpetra_block<T2>::value
   // scalar compatibility
@@ -81,8 +76,8 @@ elementwise_multiply(const alpha_t & alpha,
   assert(extent(z,0)==extent(y,0));
 
   using sc_t = typename ::pressio::Traits<T>::scalar_type;
-  sc_t alpha_{alpha};
-  sc_t beta_{beta};
+  const sc_t alpha_{alpha};
+  const sc_t beta_{beta};
 
   auto x_tpetraview = const_cast<T &>(x).getVectorView();
   auto z_tpetraview = const_cast<T1 &>(z).getVectorView();

--- a/include/pressio/ops/tpetra_block/ops_elementwise_multiply.hpp
+++ b/include/pressio/ops/tpetra_block/ops_elementwise_multiply.hpp
@@ -56,9 +56,20 @@ namespace pressio{ namespace ops{
 //----------------------------------------------------------------------
 template <typename T, typename T1, typename T2, class alpha_t, class beta_t>
 ::pressio::mpl::enable_if_t<
-  ::pressio::is_vector_tpetra_block<T>::value and
-  ::pressio::is_vector_tpetra_block<T1>::value and
-  ::pressio::is_vector_tpetra_block<T2>::value
+  // common elementwise_multiply constraints
+     ::pressio::Traits<T>::rank == 1
+  && ::pressio::Traits<T1>::rank == 1
+  && ::pressio::Traits<T2>::rank == 1
+  // TPL/container specific
+  && ::pressio::is_vector_tpetra_block<T>::value
+  && ::pressio::is_vector_tpetra_block<T1>::value
+  && ::pressio::is_vector_tpetra_block<T2>::value
+  // scalar compatibility
+  && ::pressio::all_have_traits_and_same_scalar<T, T1, T2>::value
+  && std::is_convertible<alpha_t, typename ::pressio::Traits<T>::scalar_type>::value
+  && std::is_convertible<beta_t,  typename ::pressio::Traits<T>::scalar_type>::value
+  && (std::is_floating_point<typename ::pressio::Traits<T>::scalar_type>::value
+   || std::is_integral<typename ::pressio::Traits<T>::scalar_type>::value)
   >
 elementwise_multiply(const alpha_t & alpha,
 		     const T & x,

--- a/include/pressio/ops/tpetra_block/ops_elementwise_multiply.hpp
+++ b/include/pressio/ops/tpetra_block/ops_elementwise_multiply.hpp
@@ -69,10 +69,14 @@ elementwise_multiply(const alpha_t & alpha,
   assert(extent(x,0)==extent(z,0));
   assert(extent(z,0)==extent(y,0));
 
+  using sc_t = typename ::pressio::Traits<T>::scalar_type;
+  sc_t alpha_{alpha};
+  sc_t beta_{beta};
+
   auto x_tpetraview = const_cast<T &>(x).getVectorView();
   auto z_tpetraview = const_cast<T1 &>(z).getVectorView();
   auto y_tpetraview = y.getVectorView();
-  y_tpetraview.elementWiseMultiply(alpha, x_tpetraview, z_tpetraview, beta);
+  y_tpetraview.elementWiseMultiply(alpha_, x_tpetraview, z_tpetraview, beta_);
 }
 
 }}//end namespace pressio::ops


### PR DESCRIPTION
refs #523

### Overloads

Block Tpetra `elementwise_multiply` has one overload which requires the underlying scalar type to be the same for `T`, `T1` and `T2` and to be known integral of floating-point type:
```cpp
elementwise_multiply(const alpha_t & alpha, const T & x, const T1 & z, const beta_t & beta, T2 & y)
```

| type name | requirements |
|:---:|:---|
| `T`, `T1`, `T2` | ● each must be Tpetra block vector <br>● all must have the same underlying scalar type |
| `alpha_t`, `beta_t` | must be convertible to the scalar type |

### Tests

Unit tests (in `tests/functional_small/ops/`):

| file name | test name | tested type |
|:---|:---|:---:|
| `ops_tpetra_block_vector.cc` | `ops_tpetra_block.vector_elementwiseMultiply` | `Tpetra::BlockVector<>` |