### PR TITLE
#617 CI workflows: `CI` job, get rid of pressio-builder

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -92,10 +92,13 @@ jobs:
     # https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idenv
     # A map of environment variables that are available to all steps in the job
     env:
-      pressio_dir: /__w/pressio/pressio
+      pressio_src: /__w/pressio/pressio
+      pressio_build: /home/pressio_builds
       target_dir: /out
-      eigen_path: /usr/local/eigen/install
-      gtest_path: /usr/local/gtest/install
+      eigen_inc_dir: '/usr/local/eigen/install;/usr/local/eigen/install/include/eigen3'
+      gtest_dir: /usr/local/gtest/install
+      GCC: /usr/bin/gcc
+      G++: /usr/bin/g++
       small: small
       medium: medium
       large: large
@@ -111,23 +114,23 @@ jobs:
 
       # https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsname
       # A name for your step to display on GitHub.
-      - name: configure
+      - name: Configure
 
         # https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsrun
         # Runs command-line programs using the operating system's shell.
-
-        # In this stage pressio-builder script is used for configuration purposes
         run: |
-          cd /pressio-builder
-          git pull
-          git status
-
-          sed -i 's/source .\/shared\/colors.sh/# colors commnted out/g' main_pressio.sh
-
-          ./main_pressio.sh -dryrun=no -build-mode=${{ matrix.config.mode }} \
-          -target-dir=${{env.target_dir}} -eigen-path=${{env.eigen_path}} \
-          -gtest-path=${{env.gtest_path}} -cmake-generator-name=default_with_tests \
-          -pressio-src=${{env.pressio_dir}} -ncpu-for-make=4 --config-only=yes
+          cmake -S $pressio_src -B $pressio_build \
+          -D CMAKE_BUILD_TYPE:STRING=${{ matrix.config.mode }} \
+          -D CMAKE_VERBOSE_MAKEFILE:BOOL=TRUE \
+          -D CMAKE_C_COMPILER:FILEPATH=$GCC \
+          -D CMAKE_CXX_COMPILER:FILEPATH=$G++ \
+          -D PRESSIO_ENABLE_TPL_EIGEN=ON \
+          -D EIGEN_INCLUDE_DIR=$eigen_inc_dir \
+          -D GTEST_ROOT=$gtest_dir \
+          -D PRESSIO_ENABLE_DEBUG_PRINT=ON \
+          -D PRESSIO_ENABLE_TESTS:BOOL=ON \
+          -D CMAKE_INSTALL_PREFIX:PATH=../install \
+          -D CMAKE_CXX_FLAGS=''
 
       # In this stage small functional tests are built and run
       - name: build-test-${{ env.small }}

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -97,8 +97,6 @@ jobs:
       target_dir: /out
       eigen_inc_dir: '/usr/local/eigen/install;/usr/local/eigen/install/include/eigen3'
       gtest_dir: /usr/local/gtest/install
-      GCC: /usr/bin/gcc
-      GPP: /usr/bin/g++
       small: small
       medium: medium
       large: large
@@ -122,8 +120,8 @@ jobs:
           cmake -S $pressio_src -B $pressio_build \
           -D CMAKE_BUILD_TYPE:STRING=${{ matrix.config.mode }} \
           -D CMAKE_VERBOSE_MAKEFILE:BOOL=TRUE \
-          -D CMAKE_C_COMPILER:FILEPATH=$GCC \
-          -D CMAKE_CXX_COMPILER:FILEPATH=$GPP \
+          -D CMAKE_C_COMPILER:FILEPATH=/usr/bin/gcc \
+          -D CMAKE_CXX_COMPILER:FILEPATH=/usr/bin/g++ \
           -D PRESSIO_ENABLE_TPL_EIGEN=ON \
           -D EIGEN_INCLUDE_DIR=$eigen_inc_dir \
           -D GTEST_ROOT=$gtest_dir \

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -19,7 +19,6 @@ on:
     branches:
       - 'main'
       - 'develop'
-      - 'ci-remove-pressio-builder'
     paths-ignore:
     - 'logos/**'
     - 'helper_scripts/**'
@@ -67,17 +66,17 @@ jobs:
           # os: Stands for OS on GitHub Runner (Ubuntu / MacOS / Windows)
           # image: Stands for used Docker Image
           # mode: Stands for build mode inside Pressio (Debug / Release)
-          - { os: ubuntu-latest, image: ubuntu-20.04-gnu_9-eigen_3.3.7-gtest, mode: Release }
-          - { os: ubuntu-latest, image: ubuntu-20.04-gnu_9-eigen_3.3.7-gtest, mode: Debug }
+          - { os: ubuntu-latest, image: ubuntu-20.04-gnu_9-eigen_3.3.7-gtest, mode: Release, c: gcc, cxx: g++ }
+          - { os: ubuntu-latest, image: ubuntu-20.04-gnu_9-eigen_3.3.7-gtest, mode: Debug, c: gcc, cxx: g++ }
 
-          - { os: ubuntu-latest, image: ubuntu-20.04-clang_9-eigen_3.3.7-gtest, mode: Release }
-          - { os: ubuntu-latest, image: ubuntu-20.04-clang_9-eigen_3.3.7-gtest, mode: Debug }
+          - { os: ubuntu-latest, image: ubuntu-20.04-clang_9-eigen_3.3.7-gtest, mode: Release, c: clang-9, cxx: clang++-9 }
+          - { os: ubuntu-latest, image: ubuntu-20.04-clang_9-eigen_3.3.7-gtest, mode: Debug, c: clang-9, cxx: clang++-9 }
 
-          - { os: ubuntu-latest, image: fedora-34-gnu_11-eigen_3.3.7-gtest, mode: Release }
-          - { os: ubuntu-latest, image: fedora-34-gnu_11-eigen_3.3.7-gtest, mode: Debug }
+          - { os: ubuntu-latest, image: fedora-34-gnu_11-eigen_3.3.7-gtest, mode: Release, c: gcc, cxx: g++ }
+          - { os: ubuntu-latest, image: fedora-34-gnu_11-eigen_3.3.7-gtest, mode: Debug, c: gcc, cxx: g++ }
 
-          - { os: ubuntu-latest, image: fedora-34-clang_12-eigen_3.3.7-gtest, mode: Release }
-          - { os: ubuntu-latest, image: fedora-34-clang_12-eigen_3.3.7-gtest, mode: Debug }
+          - { os: ubuntu-latest, image: fedora-34-clang_12-eigen_3.3.7-gtest, mode: Release, c: clang-9, cxx: clang++-9 }
+          - { os: ubuntu-latest, image: fedora-34-clang_12-eigen_3.3.7-gtest, mode: Debug, c: clang-9, cxx: clang++-9 }
 
           #- { os: ubuntu-latest, image: intel_oneapi-eigen_3.3.7-gtest, mode: Release }
           #- { os: ubuntu-latest, image: intel_oneapi-eigen_3.3.7-gtest, mode: Debug }
@@ -93,11 +92,11 @@ jobs:
     # https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idenv
     # A map of environment variables that are available to all steps in the job
     env:
-      pressio_src: /__w/pressio/pressio
+      pressio_dir: /home/antoine/Documents/pressio/ # TOCHANGE FOR MERGE
       pressio_build: /home/pressio_builds
       target_dir: /out
-      eigen_inc_dir: '/usr/local/eigen/install;/usr/local/eigen/install/include/eigen3'
-      gtest_dir: /usr/local/gtest/install
+      #eigen_path: /usr/local/eigen/install
+      gtest_path: /usr/local/gtest/install
       small: small
       medium: medium
       large: large
@@ -113,23 +112,27 @@ jobs:
 
       # https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsname
       # A name for your step to display on GitHub.
-      - name: Configure
+      - name: configure
 
         # https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsrun
         # Runs command-line programs using the operating system's shell.
+
+        # In this stage pressio-builder script is used for configuration purposes
+        # ==========AM================
         run: |
-          cmake -S $pressio_src -B $pressio_build \
-          -D CMAKE_BUILD_TYPE:STRING=${{ matrix.config.mode }} \
-          -D CMAKE_VERBOSE_MAKEFILE:BOOL=TRUE \
-          -D CMAKE_C_COMPILER:FILEPATH=/usr/bin/gcc \
-          -D CMAKE_CXX_COMPILER:FILEPATH=/usr/bin/g++ \
-          -D PRESSIO_ENABLE_TPL_EIGEN=ON \
-          -D EIGEN_INCLUDE_DIR=$eigen_inc_dir \
-          -D GTEST_ROOT=$gtest_dir \
-          -D PRESSIO_ENABLE_DEBUG_PRINT=ON \
-          -D PRESSIO_ENABLE_TESTS:BOOL=ON \
-          -D CMAKE_INSTALL_PREFIX:PATH=../install \
-          -D CMAKE_CXX_FLAGS=''
+          cmake -S $pressio_dir -B $pressio_build \
+            -D CMAKE_BUILD_TYPE:STRING=${{ matrix.config.mode }} \
+            -D CMAKE_VERBOSE_MAKEFILE:BOOL=TRUE \
+            -D CMAKE_C_COMPILER:FILEPATH=/usr/bin/${{ matrix.config.c }} \
+            -D CMAKE_CXX_COMPILER:FILEPATH=/usr/bin/${{ matrix.config.cxx }} \
+            -D PRESSIO_ENABLE_TPL_EIGEN=ON \
+            -D EIGEN_INCLUDE_DIR='/usr/local/eigen/install;/usr/local/eigen/install/include/eigen3' \
+            -D GTEST_ROOT=$gtest_path \
+            -D PRESSIO_ENABLE_DEBUG_PRINT=ON \
+            -D PRESSIO_ENABLE_TESTS:BOOL=ON \
+            -D CMAKE_INSTALL_PREFIX:PATH=../install \
+            -D CMAKE_CXX_FLAGS=''
+        # ==========AM================
 
       # In this stage small functional tests are built and run
       - name: build-test-${{ env.small }}

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -135,7 +135,7 @@ jobs:
       # In this stage small functional tests are built and run
       - name: build-test-${{ env.small }}
         run: |
-          cd ${{ env.pressio_build }}/pressio/build/tests/functional_${{ env.small }}
+          cd ${{ env.pressio_build }}/tests/functional_${{ env.small }}
           make -j $num_cpus
           ctest --output-on-failure
 

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -94,7 +94,6 @@ jobs:
     env:
       num_cpus: 2
       pressio_src: /__w/pressio/pressio   #local: /home/antoine/Documents/pressio/
-      pressio_build: /home/pressio_builds
       target_dir: /out
       eigen_inc_dir: /usr/local/eigen/install/include/eigen3
       gtest_dir: /usr/local/gtest/install
@@ -120,7 +119,7 @@ jobs:
 
         # In this stage pressio-builder script is used for configuration purposes
         run: |
-          cmake -S $pressio_src \
+          cmake -S $pressio_src -B $target_dir \
             -D CMAKE_BUILD_TYPE:STRING=${{ matrix.config.mode }} \
             -D CMAKE_VERBOSE_MAKEFILE:BOOL=ON \
             -D CMAKE_C_COMPILER:FILEPATH=${{ matrix.config.c }} \

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -66,17 +66,17 @@ jobs:
           # os: Stands for OS on GitHub Runner (Ubuntu / MacOS / Windows)
           # image: Stands for used Docker Image
           # mode: Stands for build mode inside Pressio (Debug / Release)
-          - { os: ubuntu-latest, image: ubuntu-20.04-gnu_9-eigen_3.3.7-gtest, mode: Release, c: /usr/bin/gcc, cxx: /usr/bin/g++ }
-          - { os: ubuntu-latest, image: ubuntu-20.04-gnu_9-eigen_3.3.7-gtest, mode: Debug, c: gcc, cxx: g++ }
+          - { os: ubuntu-latest, image: ubuntu-20.04-gnu_9-eigen_3.3.7-gtest, mode: Release }
+          - { os: ubuntu-latest, image: ubuntu-20.04-gnu_9-eigen_3.3.7-gtest, mode: Debug }
 
-          - { os: ubuntu-latest, image: ubuntu-20.04-clang_9-eigen_3.3.7-gtest, mode: Release, c: clang-9, cxx: clang++-9 }
-          - { os: ubuntu-latest, image: ubuntu-20.04-clang_9-eigen_3.3.7-gtest, mode: Debug, c: clang-9, cxx: clang++-9 }
+          - { os: ubuntu-latest, image: ubuntu-20.04-clang_9-eigen_3.3.7-gtest, mode: Release }
+          - { os: ubuntu-latest, image: ubuntu-20.04-clang_9-eigen_3.3.7-gtest, mode: Debug }
 
-          - { os: ubuntu-latest, image: fedora-34-gnu_11-eigen_3.3.7-gtest, mode: Release, c: gcc, cxx: g++ }
-          - { os: ubuntu-latest, image: fedora-34-gnu_11-eigen_3.3.7-gtest, mode: Debug, c: gcc, cxx: g++ }
+          - { os: ubuntu-latest, image: fedora-34-gnu_11-eigen_3.3.7-gtest, mode: Release }
+          - { os: ubuntu-latest, image: fedora-34-gnu_11-eigen_3.3.7-gtest, mode: Debug }
 
-          - { os: ubuntu-latest, image: fedora-34-clang_12-eigen_3.3.7-gtest, mode: Release, c: /usr/bin/clang, cxx: /usr/bin/clang++ }
-          - { os: ubuntu-latest, image: fedora-34-clang_12-eigen_3.3.7-gtest, mode: Debug, c: /usr/bin/clang, cxx: /usr/bin/clang++ }
+          - { os: ubuntu-latest, image: fedora-34-clang_12-eigen_3.3.7-gtest, mode: Release }
+          - { os: ubuntu-latest, image: fedora-34-clang_12-eigen_3.3.7-gtest, mode: Debug }
 
           #- { os: ubuntu-latest, image: intel_oneapi-eigen_3.3.7-gtest, mode: Release }
           #- { os: ubuntu-latest, image: intel_oneapi-eigen_3.3.7-gtest, mode: Debug }
@@ -122,8 +122,8 @@ jobs:
           cmake -S $pressio_src -B $pressio_build \
             -D CMAKE_BUILD_TYPE:STRING=${{ matrix.config.mode }} \
             -D CMAKE_VERBOSE_MAKEFILE:BOOL=ON \
-            -D CMAKE_C_COMPILER:FILEPATH=${{ matrix.config.c }} \
-            -D CMAKE_CXX_COMPILER:FILEPATH=${{ matrix.config.cxx }} \
+            -D CMAKE_C_COMPILER=$CC \
+            -D CMAKE_CXX_COMPILER=$CXX \
             -D PRESSIO_ENABLE_TPL_EIGEN:BOOL=ON \
             -D EIGEN_INCLUDE_DIR=$eigen_inc_dir \
             -D GTEST_ROOT=$gtest_dir \

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -98,7 +98,7 @@ jobs:
       eigen_inc_dir: '/usr/local/eigen/install;/usr/local/eigen/install/include/eigen3'
       gtest_dir: /usr/local/gtest/install
       GCC: /usr/bin/gcc
-      G++: /usr/bin/g++
+      GPP: /usr/bin/g++
       small: small
       medium: medium
       large: large
@@ -123,7 +123,7 @@ jobs:
           -D CMAKE_BUILD_TYPE:STRING=${{ matrix.config.mode }} \
           -D CMAKE_VERBOSE_MAKEFILE:BOOL=TRUE \
           -D CMAKE_C_COMPILER:FILEPATH=$GCC \
-          -D CMAKE_CXX_COMPILER:FILEPATH=$G++ \
+          -D CMAKE_CXX_COMPILER:FILEPATH=$GPP \
           -D PRESSIO_ENABLE_TPL_EIGEN=ON \
           -D EIGEN_INCLUDE_DIR=$eigen_inc_dir \
           -D GTEST_ROOT=$gtest_dir \

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -19,6 +19,7 @@ on:
     branches:
       - 'main'
       - 'develop'
+      - 'ci-remove-pressio-builder'
     paths-ignore:
     - 'logos/**'
     - 'helper_scripts/**'

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -66,7 +66,7 @@ jobs:
           # os: Stands for OS on GitHub Runner (Ubuntu / MacOS / Windows)
           # image: Stands for used Docker Image
           # mode: Stands for build mode inside Pressio (Debug / Release)
-          - { os: ubuntu-latest, image: ubuntu-20.04-gnu_9-eigen_3.3.7-gtest, mode: Release, c: gcc, cxx: g++ }
+          - { os: ubuntu-latest, image: ubuntu-20.04-gnu_9-eigen_3.3.7-gtest, mode: Release, c: /usr/bin/gcc, cxx: /usr/bin/g++ }
           - { os: ubuntu-latest, image: ubuntu-20.04-gnu_9-eigen_3.3.7-gtest, mode: Debug, c: gcc, cxx: g++ }
 
           - { os: ubuntu-latest, image: ubuntu-20.04-clang_9-eigen_3.3.7-gtest, mode: Release, c: clang-9, cxx: clang++-9 }
@@ -120,11 +120,11 @@ jobs:
 
         # In this stage pressio-builder script is used for configuration purposes
         run: |
-          cmake -S $pressio_src -B $pressio_build \
+          cmake -S $pressio_src \
             -D CMAKE_BUILD_TYPE:STRING=${{ matrix.config.mode }} \
             -D CMAKE_VERBOSE_MAKEFILE:BOOL=ON \
-            -D CMAKE_C_COMPILER:FILEPATH=/usr/bin/${{ matrix.config.c }} \
-            -D CMAKE_CXX_COMPILER:FILEPATH=/usr/bin/${{ matrix.config.cxx }} \
+            -D CMAKE_C_COMPILER:FILEPATH=${{ matrix.config.c }} \
+            -D CMAKE_CXX_COMPILER:FILEPATH=${{ matrix.config.cxx }} \
             -D PRESSIO_ENABLE_TPL_EIGEN:BOOL=ON \
             -D EIGEN_INCLUDE_DIR=$eigen_inc_dir \
             -D GTEST_ROOT=$gtest_dir \
@@ -136,10 +136,9 @@ jobs:
       # In this stage small functional tests are built and run
       - name: build-test-${{ env.small }}
         run: |
-          cmake --build $pressio_build -j $num_cpus
           cd ${{ env.target_dir }}/pressio/build/tests/functional_${{ env.small }}
           make -j $num_cpus
-          ctest -j $num_cpus --output-on-failure
+          ctest --output-on-failure
 
       # In this stage medium functional tests are built and run
       #- name: build-test-${{ env.medium }}

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -94,7 +94,7 @@ jobs:
     env:
       num_cpus: 2
       pressio_src: /__w/pressio/pressio   #local: /home/antoine/Documents/pressio/
-      target_dir: /out
+      pressio_build: /out/pressio/build
       eigen_inc_dir: /usr/local/eigen/install/include/eigen3
       gtest_dir: /usr/local/gtest/install
       small: small
@@ -119,7 +119,7 @@ jobs:
 
         # In this stage pressio-builder script is used for configuration purposes
         run: |
-          cmake -S $pressio_src -B $target_dir \
+          cmake -S $pressio_src -B $pressio_build \
             -D CMAKE_BUILD_TYPE:STRING=${{ matrix.config.mode }} \
             -D CMAKE_VERBOSE_MAKEFILE:BOOL=ON \
             -D CMAKE_C_COMPILER:FILEPATH=${{ matrix.config.c }} \
@@ -135,7 +135,7 @@ jobs:
       # In this stage small functional tests are built and run
       - name: build-test-${{ env.small }}
         run: |
-          cd ${{ env.target_dir }}/pressio/build/tests/functional_${{ env.small }}
+          cd ${{ env.pressio_build }}/pressio/build/tests/functional_${{ env.small }}
           make -j $num_cpus
           ctest --output-on-failure
 

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -75,8 +75,8 @@ jobs:
           - { os: ubuntu-latest, image: fedora-34-gnu_11-eigen_3.3.7-gtest, mode: Release, c: gcc, cxx: g++ }
           - { os: ubuntu-latest, image: fedora-34-gnu_11-eigen_3.3.7-gtest, mode: Debug, c: gcc, cxx: g++ }
 
-          - { os: ubuntu-latest, image: fedora-34-clang_12-eigen_3.3.7-gtest, mode: Release, c: clang-9, cxx: clang++-9 }
-          - { os: ubuntu-latest, image: fedora-34-clang_12-eigen_3.3.7-gtest, mode: Debug, c: clang-9, cxx: clang++-9 }
+          - { os: ubuntu-latest, image: fedora-34-clang_12-eigen_3.3.7-gtest, mode: Release, c: /usr/bin/clang, cxx: /usr/bin/clang++ }
+          - { os: ubuntu-latest, image: fedora-34-clang_12-eigen_3.3.7-gtest, mode: Debug, c: /usr/bin/clang, cxx: /usr/bin/clang++ }
 
           #- { os: ubuntu-latest, image: intel_oneapi-eigen_3.3.7-gtest, mode: Release }
           #- { os: ubuntu-latest, image: intel_oneapi-eigen_3.3.7-gtest, mode: Debug }
@@ -93,7 +93,7 @@ jobs:
     # A map of environment variables that are available to all steps in the job
     env:
       num_cpus: 2
-      pressio_src: /__w/pressio/pressio   #local: /home/antoine/Documents/pressio/
+      pressio_src: /__w/pressio/pressio
       pressio_build: /out/pressio/build
       eigen_inc_dir: /usr/local/eigen/install/include/eigen3
       gtest_dir: /usr/local/gtest/install
@@ -137,21 +137,21 @@ jobs:
         run: |
           cd ${{ env.pressio_build }}/tests/functional_${{ env.small }}
           make -j $num_cpus
-          ctest --output-on-failure
+          ctest -j $num_cpus --output-on-failure
 
       # In this stage medium functional tests are built and run
-      #- name: build-test-${{ env.medium }}
-      #  run: |
-      #    cd ${{ env.target_dir }}/pressio/build/tests/functional_${{ env.medium }}
-      #    make -j 2
-      #    ctest --output-on-failure
+      - name: build-test-${{ env.medium }}
+        run: |
+          cd ${{ env.pressio_build }}/tests/functional_${{ env.medium }}
+          make -j $num_cpus
+          ctest -j $num_cpus --output-on-failure
 
       # In this stage large functional tests are built and run
-      #- name: build-test-${{ env.large }}
-      #  run: |
-      #    cd ${{ env.target_dir }}/pressio/build/tests/functional_${{ env.large }}
-      #    make -j 2
-      #    ctest --output-on-failure
+      - name: build-test-${{ env.large }}
+        run: |
+          cd ${{ env.pressio_build }}/tests/functional_${{ env.large }}
+          make -j $num_cpus
+          ctest -j $num_cpus --output-on-failure
 
   ############################## JOB `CI-trilinos` defined below ##############################
   CI-trilinos:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -92,11 +92,12 @@ jobs:
     # https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idenv
     # A map of environment variables that are available to all steps in the job
     env:
-      pressio_dir: /home/antoine/Documents/pressio/ # TOCHANGE FOR MERGE
+      num_cpus: 2
+      pressio_src: /__w/pressio/pressio   #local: /home/antoine/Documents/pressio/
       pressio_build: /home/pressio_builds
       target_dir: /out
-      #eigen_path: /usr/local/eigen/install
-      gtest_path: /usr/local/gtest/install
+      eigen_inc_dir: /usr/local/eigen/install/include/eigen3
+      gtest_dir: /usr/local/gtest/install
       small: small
       medium: medium
       large: large
@@ -118,42 +119,41 @@ jobs:
         # Runs command-line programs using the operating system's shell.
 
         # In this stage pressio-builder script is used for configuration purposes
-        # ==========AM================
         run: |
-          cmake -S $pressio_dir -B $pressio_build \
+          cmake -S $pressio_src -B $pressio_build \
             -D CMAKE_BUILD_TYPE:STRING=${{ matrix.config.mode }} \
-            -D CMAKE_VERBOSE_MAKEFILE:BOOL=TRUE \
+            -D CMAKE_VERBOSE_MAKEFILE:BOOL=ON \
             -D CMAKE_C_COMPILER:FILEPATH=/usr/bin/${{ matrix.config.c }} \
             -D CMAKE_CXX_COMPILER:FILEPATH=/usr/bin/${{ matrix.config.cxx }} \
-            -D PRESSIO_ENABLE_TPL_EIGEN=ON \
-            -D EIGEN_INCLUDE_DIR='/usr/local/eigen/install;/usr/local/eigen/install/include/eigen3' \
-            -D GTEST_ROOT=$gtest_path \
+            -D PRESSIO_ENABLE_TPL_EIGEN:BOOL=ON \
+            -D EIGEN_INCLUDE_DIR=$eigen_inc_dir \
+            -D GTEST_ROOT=$gtest_dir \
             -D PRESSIO_ENABLE_DEBUG_PRINT=ON \
             -D PRESSIO_ENABLE_TESTS:BOOL=ON \
             -D CMAKE_INSTALL_PREFIX:PATH=../install \
             -D CMAKE_CXX_FLAGS=''
-        # ==========AM================
 
       # In this stage small functional tests are built and run
       - name: build-test-${{ env.small }}
         run: |
-            cd ${{ env.target_dir }}/pressio/build/tests/functional_${{ env.small }}
-            make -j 2
-            ctest --output-on-failure
+          cmake --build $pressio_build -j $num_cpus
+          cd ${{ env.target_dir }}/pressio/build/tests/functional_${{ env.small }}
+          make -j $num_cpus
+          ctest -j $num_cpus --output-on-failure
 
       # In this stage medium functional tests are built and run
-      - name: build-test-${{ env.medium }}
-        run: |
-          cd ${{ env.target_dir }}/pressio/build/tests/functional_${{ env.medium }}
-          make -j 2
-          ctest --output-on-failure
+      #- name: build-test-${{ env.medium }}
+      #  run: |
+      #    cd ${{ env.target_dir }}/pressio/build/tests/functional_${{ env.medium }}
+      #    make -j 2
+      #    ctest --output-on-failure
 
       # In this stage large functional tests are built and run
-      - name: build-test-${{ env.large }}
-        run: |
-          cd ${{ env.target_dir }}/pressio/build/tests/functional_${{ env.large }}
-          make -j 2
-          ctest --output-on-failure
+      #- name: build-test-${{ env.large }}
+      #  run: |
+      #    cd ${{ env.target_dir }}/pressio/build/tests/functional_${{ env.large }}
+      #    make -j 2
+      #    ctest --output-on-failure
 
   ############################## JOB `CI-trilinos` defined below ##############################
   CI-trilinos:


### PR DESCRIPTION
Solution for issue #617 part 1/2.

Remove `pressio-builder` and replace it with the pure `cmake` command.