### PR TITLE
set shift to zero if non affine is selected

### DIFF
--- a/include/pressio/rom/impl/linear_trial_column_subspace.hpp
+++ b/include/pressio/rom/impl/linear_trial_column_subspace.hpp
@@ -58,7 +58,10 @@ public:
     : linSpace_(basisMatrix,
 		linear_subspace_t::SpanningSet::Columns),
       translation_(translation),
-      isAffine_(isAffine){}
+      isAffine_(isAffine)
+  {
+    setShiftToZeroIfNonAffine();
+  }
 
   TrialColumnSubspace(basis_matrix_type && basisMatrix,
 		      full_state_type && translation,
@@ -66,7 +69,10 @@ public:
     : linSpace_(std::move(basisMatrix),
 		linear_subspace_t::SpanningSet::Columns),
       translation_(std::move(translation)),
-      isAffine_(isAffine){}
+      isAffine_(isAffine)
+  {
+    setShiftToZeroIfNonAffine();
+  }
 
   TrialColumnSubspace(const basis_matrix_type & basisMatrix,
 		      full_state_type && translation,
@@ -74,7 +80,10 @@ public:
     : linSpace_(basisMatrix,
 		linear_subspace_t::SpanningSet::Columns),
       translation_(std::move(translation)),
-      isAffine_(isAffine){}
+      isAffine_(isAffine)
+  {
+    setShiftToZeroIfNonAffine();
+  }
 
   TrialColumnSubspace(basis_matrix_type && basisMatrix,
 		      const full_state_type & translation,
@@ -82,12 +91,18 @@ public:
     : linSpace_(std::move(basisMatrix),
 		linear_subspace_t::SpanningSet::Columns),
       translation_(translation),
-      isAffine_(isAffine){}
+      isAffine_(isAffine)
+  {
+    setShiftToZeroIfNonAffine();
+  }
 
   TrialColumnSubspace(const TrialColumnSubspace & other)
     : linSpace_(other.linSpace_),
       translation_(::pressio::ops::clone(other.translation_)),
-      isAffine_(other.isAffine_){}
+      isAffine_(other.isAffine_)
+  {
+    setShiftToZeroIfNonAffine();
+  }
 
   /* For this class to be really immutable, we should not have a
      move assign operator and copy assign.
@@ -159,6 +174,12 @@ public:
   }
 
 private:
+  void setShiftToZeroIfNonAffine(){
+    if (!isAffine_){
+      ::pressio::ops::fill(translation_, 0);
+    }
+  }
+
   void mapFromReducedStateWithoutTranslation(const reduced_state_type & latState,
 					     full_state_type & fullState) const
   {

--- a/include/pressio/rom/impl/linear_trial_column_subspace.hpp
+++ b/include/pressio/rom/impl/linear_trial_column_subspace.hpp
@@ -47,7 +47,7 @@ public:
 private:
   using linear_subspace_t = LinearSubspace<basis_matrix_type>;
   const linear_subspace_t linSpace_;
-  const full_state_type translation_;
+  full_state_type translation_;
   bool isAffine_;
   basis_matrix_type * dummy_ = nullptr;
 

--- a/tests/functional_small/rom/trial_subspace_stdvec_full_state_eigen_reduced_state.cc
+++ b/tests/functional_small/rom/trial_subspace_stdvec_full_state_eigen_reduced_state.cc
@@ -308,3 +308,18 @@ TEST(rom, affine_trial_subspace_view_basis)
   auto & J = space.basis();
   EXPECT_TRUE( J.isApprox(phi) );
 }
+
+
+TEST(rom, trial_subspace_shift_is_zero_if_nonaffine)
+{
+  using namespace pressio::rom;
+
+  using basis_t = Eigen::MatrixXd;
+  basis_t phi;
+  using reduced_state_type = Eigen::VectorXd;
+  const double fillvalueshift = 1145.4;
+  std::vector<double> shift(15, fillvalueshift);
+  auto space = create_trial_column_subspace<reduced_state_type>(phi, shift, false);
+  const auto & shiftStored = space.translationVector();
+  ASSERT_TRUE( std::all_of(shiftStored.cbegin(), shiftStored.cend(), [](auto v){ return v==0; }) );
+}

--- a/tests/functional_small/rom/trial_subspace_stdvec_full_state_eigen_reduced_state.cc
+++ b/tests/functional_small/rom/trial_subspace_stdvec_full_state_eigen_reduced_state.cc
@@ -18,8 +18,8 @@ std::vector<T> clone(const std::vector<T> & o){
   return o;
 }
 
-template<class T>
-void fill(std::vector<T> & o, T value){
+template<class T, class ValT>
+void fill(std::vector<T> & o, ValT value){
   std::for_each(o.begin(), o.end(), [=](T & entry){ entry = value; });
 }
 


### PR DESCRIPTION
this is to ensure that any shift vector passed to trial space is set to zero if the trial space is non affine. 
otherwise, if one passes a temporary vec that could have all sort of weird initializations leading to problems when used