### PR TITLE
add Trilinos 14.4.0 image and build

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -16,12 +16,13 @@ jobs:
     strategy:
       matrix:
         config:
-          - {dockerfile: 'fedora-clang',            compiler-version: '17'}
-          - {dockerfile: 'fedora-gnu',              compiler-version: '13'}
+          - {dockerfile: 'fedora-clang',        compiler-version: '17', tag: 'latest'}
+          - {dockerfile: 'fedora-gnu',          compiler-version: '13', tag: 'latest'}
           # - {dockerfile: 'intel-oneapi',            compiler-version: 'latest'}
-          - {dockerfile: 'ubuntu-clang',         compiler-version: '14'}
-          - {dockerfile: 'ubuntu-gnu-trilinos',  compiler-version: '11'}
-          - {dockerfile: 'ubuntu-gnu',           compiler-version: '11'}
+          - {dockerfile: 'ubuntu-clang',        compiler-version: '14', tag: 'latest'}
+          - {dockerfile: 'ubuntu-gnu-trilinos', compiler-version: '11', tag: 'ef73d14'}
+          - {dockerfile: 'ubuntu-gnu-trilinos', compiler-version: '11', tag: 'trilinos-release-14-4-0'}
+          - {dockerfile: 'ubuntu-gnu',          compiler-version: '11', tag: 'latest'}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -41,9 +42,10 @@ jobs:
       - name: Build and Push Docker images for Github Container Registry
         uses: docker/build-push-action@v4
         with:
-          tags: ghcr.io/pressio/${{ matrix.config.dockerfile }}-${{ matrix.config.compiler-version }}:latest
+          tags: ghcr.io/pressio/${{ matrix.config.dockerfile }}-${{ matrix.config.compiler-version }}:${{ matrix.config.tag }}
           file: docker_scripts/${{ matrix.config.dockerfile }}.dockerfile
           build-args: |
             COMPILER_VERSION=${{ matrix.config.compiler-version }}
+            DOCKER_TAG=${{ matrix.config.tag }}
           pull: true
           push: ${{ github.repository == 'Pressio/pressio' && github.ref == 'refs/heads/develop' }}

--- a/.github/workflows/ci-trilinos.yml
+++ b/.github/workflows/ci-trilinos.yml
@@ -31,12 +31,15 @@ jobs:
       matrix:
         image:
           - ubuntu-gnu-trilinos-11
+        tag:
+          - ef73d14
+          - trilinos-release-14-4-0
         build_type:
           - Release
           - Debug
 
     runs-on: ubuntu-latest
-    container: ghcr.io/pressio/${{ matrix.image }}
+    container: ghcr.io/pressio/${{ matrix.image }}:${{ matrix.tag }}
 
     env:
       eigen_version: 3.4.0

--- a/docker_scripts/ubuntu-gnu-trilinos.dockerfile
+++ b/docker_scripts/ubuntu-gnu-trilinos.dockerfile
@@ -1,6 +1,7 @@
 ARG UBUNTU_VERSION=22.04
 FROM ubuntu:${UBUNTU_VERSION}
 
+ARG CMAKE_VERSION=3.27.8
 ARG COMPILER_VERSION=11
 ARG CC=gcc-${COMPILER_VERSION}
 ARG CXX=g++-${COMPILER_VERSION}
@@ -12,7 +13,6 @@ RUN apt-get update -y -q && \
     apt-get upgrade -y -q && \
     apt-get install -y -q --no-install-recommends \
         ca-certificates \
-        cmake \
         git \
         libgtest-dev \
         liblapack-dev \
@@ -25,6 +25,11 @@ RUN apt-get update -y -q && \
         $CC $CXX $GFORTRAN && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+# CMake installation
+RUN wget -O cmake.sh https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-${CMAKE_VERSION}-Linux-x86_64.sh && \
+    sh cmake.sh --skip-license --exclude-subdir --prefix=/usr/local/ && \
+    rm cmake.sh
 
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/${CC} 10
 RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/${CXX} 10

--- a/docker_scripts/ubuntu-gnu-trilinos.dockerfile
+++ b/docker_scripts/ubuntu-gnu-trilinos.dockerfile
@@ -48,7 +48,7 @@ ENV MPIRUNe=/usr/bin/mpirun
 WORKDIR /home
 RUN git clone https://github.com/trilinos/Trilinos.git && \
     cd Trilinos && \
-    git checkout ef73d14babf6e7556b0420add98cce257ccaa56b
+    git checkout trilinos-release-14-4-0
 
 RUN cmake -B Trilinos/builddir \
         -D CMAKE_BUILD_TYPE:STRING=Release \

--- a/docker_scripts/ubuntu-gnu-trilinos.dockerfile
+++ b/docker_scripts/ubuntu-gnu-trilinos.dockerfile
@@ -6,6 +6,7 @@ ARG COMPILER_VERSION=11
 ARG CC=gcc-${COMPILER_VERSION}
 ARG CXX=g++-${COMPILER_VERSION}
 ARG GFORTRAN=gfortran-${COMPILER_VERSION}
+ARG DOCKER_TAG=trilinos-release-14-4-0
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -53,7 +54,7 @@ ENV MPIRUNe=/usr/bin/mpirun
 WORKDIR /home
 RUN git clone https://github.com/trilinos/Trilinos.git && \
     cd Trilinos && \
-    git checkout trilinos-release-14-4-0
+    git checkout ${DOCKER_TAG}
 
 RUN cmake -B Trilinos/builddir \
         -D CMAKE_BUILD_TYPE:STRING=Release \


### PR DESCRIPTION
Add another set of CI jobs using [Trilinos 14.4.0](https://github.com/trilinos/Trilinos/releases/tag/trilinos-release-14-4-0).

Note: add that and leave existing builds (using Trilinos `ef73d14`) too.