### PR TITLE
use owing ptr, fixes usecase for schwarz

### DIFF
--- a/include/pressio/rom/impl/lspg_unsteady_problem.hpp
+++ b/include/pressio/rom/impl/lspg_unsteady_problem.hpp
@@ -58,9 +58,11 @@ public:
 		      const FomSystemType & fomSystem,
 		      Args && ... args)
     : fomStatesManager_(create_lspg_fom_states_manager(odeSchemeName, trialSubspace)),
-      rjPolicyOrFullyDiscreteSystem_(trialSubspace, fomSystem, fomStatesManager_,
-				     std::forward<Args>(args)...),
-      stepper_( ::pressio::ode::create_implicit_stepper(odeSchemeName, rjPolicyOrFullyDiscreteSystem_))
+      rjPolicyOrFullyDiscreteSystem_(std::make_unique<ResJacPolicyOrFullyDiscreteSystemType>(trialSubspace,
+											     fomSystem,
+											     fomStatesManager_,
+											     std::forward<Args>(args)...)),
+      stepper_( ::pressio::ode::create_implicit_stepper(odeSchemeName, *rjPolicyOrFullyDiscreteSystem_))
   {}
 
   template<
@@ -74,10 +76,11 @@ public:
 		      Args && ... args)
     : fomStatesManager_(create_lspg_fom_states_manager<
 			_TotalNumberOfDesiredStates>(trialSubspace)),
-      rjPolicyOrFullyDiscreteSystem_(trialSubspace, fomSystem, fomStatesManager_,
-				     std::forward<Args>(args)...),
+      rjPolicyOrFullyDiscreteSystem_(std::make_unique<ResJacPolicyOrFullyDiscreteSystemType>(trialSubspace, fomSystem,
+											     fomStatesManager_,
+											     std::forward<Args>(args)...)),
       stepper_( ::pressio::ode::create_implicit_stepper<
-		_TotalNumberOfDesiredStates>(rjPolicyOrFullyDiscreteSystem_))
+		_TotalNumberOfDesiredStates>(*rjPolicyOrFullyDiscreteSystem_))
   {}
 
   stepper_type & lspgStepper(){ return stepper_; }
@@ -96,7 +99,7 @@ public:
 
 private:
   LspgFomStatesManager<TrialSubspaceType> fomStatesManager_;
-  ResJacPolicyOrFullyDiscreteSystemType rjPolicyOrFullyDiscreteSystem_;
+  std::unique_ptr<ResJacPolicyOrFullyDiscreteSystemType> rjPolicyOrFullyDiscreteSystem_;
   stepper_type stepper_;
 };
 

--- a/include/pressio/rom/impl/lspg_unsteady_problem.hpp
+++ b/include/pressio/rom/impl/lspg_unsteady_problem.hpp
@@ -57,10 +57,10 @@ public:
 		      const TrialSubspaceType & trialSubspace,
 		      const FomSystemType & fomSystem,
 		      Args && ... args)
-    : fomStatesManager_(create_lspg_fom_states_manager(odeSchemeName, trialSubspace)),
+    : fomStatesManager_(std::make_unique<LspgFomStatesManager<TrialSubspaceType>>(create_lspg_fom_states_manager(odeSchemeName, trialSubspace))),
       rjPolicyOrFullyDiscreteSystem_(std::make_unique<ResJacPolicyOrFullyDiscreteSystemType>(trialSubspace,
 											     fomSystem,
-											     fomStatesManager_,
+											     *fomStatesManager_,
 											     std::forward<Args>(args)...)),
       stepper_( ::pressio::ode::create_implicit_stepper(odeSchemeName, *rjPolicyOrFullyDiscreteSystem_))
   {}
@@ -74,10 +74,10 @@ public:
   LspgUnsteadyProblem(const TrialSubspaceType & trialSubspace,
 		      const FomSystemType & fomSystem,
 		      Args && ... args)
-    : fomStatesManager_(create_lspg_fom_states_manager<
-			_TotalNumberOfDesiredStates>(trialSubspace)),
+    : fomStatesManager_(std::make_unique<LspgFomStatesManager<TrialSubspaceType>>(create_lspg_fom_states_manager<
+				  _TotalNumberOfDesiredStates>(trialSubspace))),
       rjPolicyOrFullyDiscreteSystem_(std::make_unique<ResJacPolicyOrFullyDiscreteSystemType>(trialSubspace, fomSystem,
-											     fomStatesManager_,
+											     *fomStatesManager_,
 											     std::forward<Args>(args)...)),
       stepper_( ::pressio::ode::create_implicit_stepper<
 		_TotalNumberOfDesiredStates>(*rjPolicyOrFullyDiscreteSystem_))
@@ -98,7 +98,7 @@ public:
   }
 
 private:
-  LspgFomStatesManager<TrialSubspaceType> fomStatesManager_;
+  std::unique_ptr<LspgFomStatesManager<TrialSubspaceType>> fomStatesManager_;
   std::unique_ptr<ResJacPolicyOrFullyDiscreteSystemType> rjPolicyOrFullyDiscreteSystem_;
   stepper_type stepper_;
 };


### PR DESCRIPTION
this is not the proper fix. The proper fix is to move what we can move, similarly to what we do for galerkin.
But doing so will require fixing the move semantics for good everywhere by actually thinking about it properly!