### PR TITLE
#726: Clean up docs and version

### DIFF
--- a/docs/source/concepts_note.rst
+++ b/docs/source/concepts_note.rst
@@ -3,8 +3,8 @@
 
 .. include:: mydefs.rst
 
-pressio concepts: more info
-===========================
+Concepts in Pressio
+===================
 
 Concept-driven design has been and still is critical in
 the development of pressio. Here we describe some fundamental

--- a/docs/source/concepts_note.rst
+++ b/docs/source/concepts_note.rst
@@ -23,7 +23,7 @@ and semantics are specified/listed as comments. Here, we adopt a different
 approach to present axioms (similar to "Design of Concept Libraries for C++", 2011)),
 that we believe benefits readability: axioms are explicitly listed using
 the keyword "axiom". Note, however, that if you want to compile the concepts below
-using a c++20 compiler, you have to comment out all axioms.
+using a C++20 compiler, you have to comment out all axioms.
 
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,11 +28,13 @@ author = 'Francesco Rizzi'
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.
 def get_version():
-  local_version = ''
-  with open("../../version.txt") as version_file:
-    for line in version_file.read().strip().split("\n"):
-      local_version = local_version + line.split(" ")[1] + '.'
-    return local_version[:-1]
+    version_splits = []
+    with open("../../include/pressio/pressio_macros.hpp") as version_file:
+        for line in version_file:
+            splits = line.strip().split()
+            if len(splits) == 3 and "VERSION" in splits[1]:
+                version_splits.append(splits[2])
+    return ".".join(version_splits)
 
 # The full version, including alpha/beta/rc tags
 release = get_version()

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -131,7 +131,7 @@ The following steps explain how to build and runs the Pressio tests.
    cd <where-you-cloned-pressio>
    mkdir build && mkdir install
 
-3. Use cmake to configure by passing to the command line the target list of cmake variables to define.
+3. Use cmake to configure by passing to the command line the target list of CMake variables to define.
 
 For example, suppose we want to enable support for Trilinos and the logger. We would do:
 
@@ -149,7 +149,7 @@ For example, suppose we want to enable support for Trilinos and the logger. We w
 
 Note that this step **only builds tests** because ``pressio`` is header-only.
 If you want, inspect the file ``<where-you-cloned-pressio>/install/pressio_cmake_config.h``
-which contains the cmake variables configuration.
+which contains the CMake variables configuration.
 
 By default, this step will also clone and link to the ``Pressio/pressio-ops`` library,
 which contains essential operations for ``pressio``.

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -45,16 +45,16 @@ Optional vs Required
      - Version Known to Work/run in CI
    * - Eigen
      - Required
-     - 3.3.7
+     - 3.4.0
    * - Trilinos
      - Optional
-     - commit: ef73d14babf6e7556b0420add98cce257ccaa56b
+     - commits: 0dc4553, 5bbda25
    * - MPI
      - Optional
      - --
    * - Kokkos
      - Optional
-     - 3.1.0
+     - 4.4.01
    * - BLAS
      - Optional
      - --
@@ -63,7 +63,7 @@ Optional vs Required
      - --
    * - GoogleTest
      - Optional
-     - 1.10.0
+     - 1.14.0
 
 Eigen is the only required dependency because it is the
 default choice for instantiating the ROM data structures

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -69,7 +69,7 @@ Each component (level) of the stack depends on the ones below it.
      - ``<pressio/solvers_linear.hpp>``
 
 
-These components depend on the `Pressio/pressio-ops <https://github.com/Pressio/pressio-ops>`_ library, which is pulled in automatically when the ``pressio`` tests are built.
+These components depend on the `Pressio/pressio-ops <https://github.com/Pressio/pressio-ops>`_ header-only library.
 
 Get Started
 -----------
@@ -96,15 +96,14 @@ C++20 concepts are, in some sense, a way to *explicitly* formalize those expecta
 
 Until we can stably upgrade to C++20, we cannot by default use C++20 concepts,
 so we currently guard the concepts in pressio inside a
-preprocessor directive ``#ifdef PRESSIO_ENABLE_CXX20``. This can be enabled by
-using a C++20 compliant compiler and setting ``-DCMAKE_CXX_STANDARD=20`` at configure time.
+preprocessor directive ``#ifdef PRESSIO_ENABLE_CXX20``.
 The behavior is as follows:
 
 - if ``PRESSIO_ENABLE_CXX20`` is *enabled*: concepts are compiled and
   enforced *stricto sensu* on the pressio APIs as discussed by this documentation
 
 - if ``PRESSIO_ENABLE_CXX20`` is *disabled*: this is the default case because the
-  default pressio C++ standard is currently C++14. In this case, the "C++20 concepts"
+  default pressio C++ standard is currently C++17. In this case, the "C++20 concepts"
   are not compiled but the constraints they represent are still valid and implemented
   differently such that their enforcement is done via a combination of SFINAE and static asserts.
 
@@ -115,7 +114,7 @@ The behavior is as follows:
    focus on the syntax, then then we will revise them with proper semantics. Keep this in mind
    if some concepts seem incomplete.
 
-Read more about `concepts in Pressio <concepts_note>`_.
+Read more about `concepts in Pressio <concepts_note.html>`_.
 
 ..
    Here, the term concept does not necessarily

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -115,6 +115,8 @@ The behavior is as follows:
    focus on the syntax, then then we will revise them with proper semantics. Keep this in mind
    if some concepts seem incomplete.
 
+Read more about `concepts in Pressio <concepts_note>`_.
+
 ..
    Here, the term concept does not necessarily
    refer to the C++ concepts feature introduced in C++20.
@@ -148,6 +150,7 @@ open an issue on `github <https://github.com/Pressio/pressio>`_.
 
    configuration
    keywords
+   concepts_note
 
 .. toctree::
    :caption: API

--- a/include/pressio/pressio_macros.hpp
+++ b/include/pressio/pressio_macros.hpp
@@ -52,7 +52,7 @@
 #include "pressio/ops_macros.hpp"
 
 #define PRESSIO_MAJOR_VERSION 0
-#define PRESSIO_MINOR_VERSION 14
+#define PRESSIO_MINOR_VERSION 15
 #define PRESSIO_PATCH_VERSION 0
 
 #if PRESSIO_ENABLE_LOGGING

--- a/include/pressio/pressio_macros.hpp
+++ b/include/pressio/pressio_macros.hpp
@@ -51,6 +51,10 @@
 
 #include "pressio/ops_macros.hpp"
 
+#define PRESSIO_MAJOR_VERSION 0
+#define PRESSIO_MINOR_VERSION 14
+#define PRESSIO_PATCH_VERSION 0
+
 #if PRESSIO_ENABLE_LOGGING
     #include "pressio-log/core.hpp"
     #define PRESSIOLOG_SOLVERS_DIAGNOSTICS_ONLY(...) PRESSIOLOG_SPARSE(__VA_ARGS__)

--- a/tests/cmake/version.cmake
+++ b/tests/cmake/version.cmake
@@ -2,13 +2,13 @@
 # versioning
 #=====================================================================
 # adapted from Eigen
-file(READ "${PRESSIO_OPS_INCLUDE_DIR}/pressio/ops_macros.hpp" _pressio_ops_macros)
+file(READ "${CMAKE_SOURCE_DIR}/include/pressio/pressio_macros.hpp" _pressio_macros)
 
-string(REGEX MATCH "define[ \t]+PRESSIO_MAJOR_VERSION[ \t]+([0-9]+)" _pressio_major_version_match "${_pressio_ops_macros}")
+string(REGEX MATCH "define[ \t]+PRESSIO_MAJOR_VERSION[ \t]+([0-9]+)" _pressio_major_version_match "${_pressio_macros}")
 set(PRESSIO_MAJOR_VERSION "${CMAKE_MATCH_1}")
-string(REGEX MATCH "define[ \t]+PRESSIO_MINOR_VERSION[ \t]+([0-9]+)" _pressio_minor_version_match "${_pressio_ops_macros}")
+string(REGEX MATCH "define[ \t]+PRESSIO_MINOR_VERSION[ \t]+([0-9]+)" _pressio_minor_version_match "${_pressio_macros}")
 set(PRESSIO_MINOR_VERSION "${CMAKE_MATCH_1}")
-string(REGEX MATCH "define[ \t]+PRESSIO_PATCH_VERSION[ \t]+([0-9]+)" _pressio_patch_version_match "${_pressio_ops_macros}")
+string(REGEX MATCH "define[ \t]+PRESSIO_PATCH_VERSION[ \t]+([0-9]+)" _pressio_patch_version_match "${_pressio_macros}")
 set(PRESSIO_PATCH_VERSION "${CMAKE_MATCH_1}")
 set(PRESSIO_VERSION_NUMBER ${PRESSIO_MAJOR_VERSION}.${PRESSIO_MINOR_VERSION}.${PRESSIO_PATCH_VERSION})
 message("${Magenta}>> PRESSIO: version = ${PRESSIO_VERSION_NUMBER} ${ColourReset}")


### PR DESCRIPTION
Fixes #726 

This PR:
- Adds `PRESSIO_*_VERSION` macros to the pressio library (Instead of using the versions defined in `pressio-ops`)
- Fixes the version of Pressio in the documentation
- Updates the versions of TPLs in the documentation to reflect current CI
- Other drive-by fixes in the documentation